### PR TITLE
Fix redundant .click() in small-menu.js on window resize

### DIFF
--- a/js/small-menu.js
+++ b/js/small-menu.js
@@ -9,7 +9,7 @@ jQuery( document ).ready( function( $ ) {
 		$masthead.find( '.site-navigation' ).removeClass( 'main-navigation' ).addClass( 'main-small-navigation' );
 		$masthead.find( '.site-navigation h1' ).removeClass( 'assistive-text' ).addClass( 'menu-toggle' );
 
-		$( '.menu-toggle' ).click( function() {
+		$( '.menu-toggle' ).unbind( 'click' ).click( function() {
 			$masthead.find( '.menu' ).toggle();
 			$( this ).toggleClass( 'toggled-on' );
 		} );


### PR DESCRIPTION
The <code>.click()</code> event in small-menu.js that toggles the <code>.menu</code> element is re-bound each time the window is resized. This causes multiple <code>.click()</code> events to be bound to the <code>.menu-toggle</code> element, effectively cancelling out the <code>.toggle()</code> function every other time the window is resized (change <code>.toggle()</code> to <code>.slideToggle()</code> to really see the effect).

By using <code>.unbind( 'click' )</code> before <code>.click()</code>, this is no longer an issue. With jQuery 1.7 you could also use <code>.off( 'click' )</code> instead.
