### PR TITLE
Use get_header_textcolor() for forward compatibility

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -117,10 +117,10 @@ if ( ! function_exists( '_s_admin_header_image' ) ) :
 function _s_admin_header_image() { ?>
 	<div id="headimg">
 		<?php
-		if ( 'blank' == get_theme_mod( 'header_textcolor', HEADER_TEXTCOLOR ) || '' == get_theme_mod( 'header_textcolor', HEADER_TEXTCOLOR ) )
+		if ( 'blank' == get_header_textcolor() || '' == get_header_textcolor() )
 			$style = ' style="display:none;"';
 		else
-			$style = ' style="color:#' . get_theme_mod( 'header_textcolor', HEADER_TEXTCOLOR ) . ';"';
+			$style = ' style="color:#' . get_header_textcolor() . ';"';
 		?>
 		<h1><a id="name"<?php echo $style; ?> onclick="return false;" href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
 		<div id="desc"<?php echo $style; ?>><?php bloginfo( 'description' ); ?></div>


### PR DESCRIPTION
This could smoothen the transition to 3.4 and it reduces code in `_s`.
Already used in `_s_header_style()`.
