### PR TITLE
Changed the for attribute of a label - typo

### DIFF
--- a/inc/theme-options/theme-options.php
+++ b/inc/theme-options/theme-options.php
@@ -169,7 +169,7 @@ function _s_get_theme_options() {
 function _s_settings_field_sample_checkbox() {
 	$options = _s_get_theme_options();
 	?>
-	<label for"sample-checkbox">
+	<label for="sample-checkbox">
 		<input type="checkbox" name="_s_theme_options[sample_checkbox]" id="sample-checkbox" <?php checked( 'on', $options['sample_checkbox'] ); ?> />
 		<?php _e( 'A sample checkbox.', '_s' ); ?>
 	</label>


### PR DESCRIPTION
Spotted a typo in a label tag of the theme-options.php.
