### PR TITLE
Adding current search query to searchform.php

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -8,6 +8,6 @@
 ?>
 	<form method="get" id="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>" role="search">
 		<label for="s" class="assistive-text"><?php _e( 'Search', '_s' ); ?></label>
-		<input type="text" class="field" name="s" id="s" placeholder="<?php esc_attr_e( 'Search &hellip;', '_s' ); ?>" />
+		<input type="text" class="field" name="s" value="<?php echo esc_attr( get_search_query() ); ?>" id="s" placeholder="<?php esc_attr_e( 'Search &hellip;', '_s' ); ?>" />
 		<input type="submit" class="submit" name="submit" id="searchsubmit" value="<?php esc_attr_e( 'Search', '_s' ); ?>" />
 	</form>


### PR DESCRIPTION
It may be useful to display what the user searched for in the search input, especially on pages like no-results.php where the search query is not displayed anywhere.
