### PR TITLE
Don't print markup in _s_content_nav() when it is not needed. Fixes #28.

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -15,7 +15,20 @@ if ( ! function_exists( '_s_content_nav' ) ):
  * @since _s 1.0
  */
 function _s_content_nav( $nav_id ) {
-	global $wp_query;
+	global $wp_query, $post;
+
+	// Don't print empty markup on single pages if there's nowhere to navigate.
+	if ( is_single() ) {
+		$previous = ( is_attachment() ) ? get_post( $post->post_parent ) : get_adjacent_post( false, '', true );
+		$next = get_adjacent_post( false, '', false );
+
+		if ( ! $next && ! $previous )
+			return;
+	}
+
+	// Don't print empty markup in archives if there's only one page.
+	if ( $wp_query->max_num_pages < 2 && ( is_home() || is_archive() || is_search() ) )
+		return;
 
 	$nav_class = 'site-navigation paging-navigation';
 	if ( is_single() )


### PR DESCRIPTION
Added checks for previous (or parent) and next post in `_s_content_nav()` before printing any navigation-specific markup. Same approach for when using the function to print pagination links on a posts set for less than two pages.
