### PR TITLE
Removes default focus outline on inputs, adding cleaner border instead

### DIFF
--- a/style.css
+++ b/style.css
@@ -297,7 +297,9 @@ textarea {
 input[type=text]:focus,
 input[type=email]:focus,
 textarea:focus {
+	border: 1px solid #888;
 	color: #111;
+	outline: 0;
 }
 input[type=text],
 input[type=email] {


### PR DESCRIPTION
The default input focus outline is hideous in Safari (fuzzy blue), and under some circumstances, can appear cut-off.

This removes the default input focus outline, adding a minimal dark border upon focus instead.
