### PR TITLE
make html tags to have IE related classes to ease in cross browser fixes

### DIFF
--- a/header.php
+++ b/header.php
@@ -8,7 +8,10 @@
  * @since _s 1.0
  */
 ?><!DOCTYPE html>
-<html <?php language_attributes(); ?>>
+<!--[if lt IE 7]> <html class="lt-ie9 lt-ie8 lt-ie7" <?php language_attributes(); ?>> <![endif]-->
+<!--[if IE 7]>    <html class="lt-ie9 lt-ie8" <?php language_attributes(); ?>> <![endif]-->
+<!--[if IE 8]>    <html class="lt-ie9" <?php language_attributes(); ?>> <![endif]-->
+<!--[if gt IE 8]><!--> <html <?php language_attributes(); ?>> <!--<![endif]-->
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width" />


### PR DESCRIPTION
How about incorporating **HTML5BP / Paul Irish's** method of adding IE related classes to HTML tag so that it helps/encourage front end developers to use best practices while making their design cross browser?

This will make users to have a cleaner code and since **_s** is like the WordPress theme boilerplate, I think it will be good to have this in. Thoughts?

Let me know if it would be good to add some pointers or usage example in style.css for preaching about this technique.

P.S. - As seen in HTML5 boilerplate v3 - http://html5boilerplate.com
