### PR TITLE
s/double/single quotes in register_sidebar args array.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -89,7 +89,7 @@ function _s_widgets_init() {
 		'name' => __( 'Sidebar', '_s' ),
 		'id' => 'sidebar-1',
 		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
-		'after_widget' => "</aside>",
+		'after_widget' => '</aside>',
 		'before_title' => '<h1 class="widget-title">',
 		'after_title' => '</h1>',
 	) );


### PR DESCRIPTION
This is probably left over from a time when there was a line break
following the HTML tag.
