### PR TITLE
Only show publish promo to users that can publish posts

### DIFF
--- a/no-results.php
+++ b/no-results.php
@@ -15,7 +15,7 @@
 	</header><!-- .entry-header -->
 
 	<div class="entry-content">
-		<?php if ( is_home() ) : ?>
+		<?php if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
 			<p><?php printf( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', '_s' ), admin_url( 'post-new.php' ) ); ?></p>
 


### PR DESCRIPTION
In our no-results template, there's no point in displaying a "publish your first post" promo to users that don't have the ability to publish posts since they can't act on it.
