### PR TITLE
Don't show separator between meta block and Leave a Comment link in pages contained within search results.

### DIFF
--- a/content.php
+++ b/content.php
@@ -52,8 +52,10 @@
 		<?php endif; // End if 'post' == get_post_type() ?>
 
 		<?php if ( ! post_password_required() && ( comments_open() || '0' != get_comments_number() ) ) : ?>
-		<span class="sep"> | </span>
-		<span class="comments-link"><?php comments_popup_link( __( 'Leave a comment', '_s' ), __( '1 Comment', '_s' ), __( '% Comments', '_s' ) ); ?></span>
+			<?php if ( 'post' == get_post_type() ) : ?>
+				<span class="sep"> | </span>
+			<?php endif; // End if 'post' == get_post_type() ?>
+			<span class="comments-link"><?php comments_popup_link( __( 'Leave a comment', '_s' ), __( '1 Comment', '_s' ), __( '% Comments', '_s' ) ); ?></span>
 		<?php endif; ?>
 
 		<?php edit_post_link( __( 'Edit', '_s' ), '<span class="sep"> | </span><span class="edit-link">', '</span>' ); ?>


### PR DESCRIPTION
Extra entry meta separator is present for pages visible in search results. Verify that what's being displayed is a post before outputting a separator before the Leave a Comment link

![Alt text](http://p-am.net/grabs/sep-20120904-150600.png)
