### PR TITLE
Add 'site-navigation' class to image.php's image navigation container

### DIFF
--- a/image.php
+++ b/image.php
@@ -34,7 +34,7 @@ get_header();
 							<?php edit_post_link( __( 'Edit', '_s' ), '<span class="sep"> | </span> <span class="edit-link">', '</span>' ); ?>
 						</div><!-- .entry-meta -->
 
-						<nav id="image-navigation">
+						<nav id="image-navigation" class="site-navigation">
 							<span class="previous-image"><?php previous_image_link( false, __( '&larr; Previous', '_s' ) ); ?></span>
 							<span class="next-image"><?php next_image_link( false, __( 'Next &rarr;', '_s' ) ); ?></span>
 						</nav><!-- #image-navigation -->


### PR DESCRIPTION
All site navigation containers in _s use the class 'site-navigation' except the one in image.php. Let's fix that for better consistency with regard to post navigation styling.
