### PR TITLE
Changing H1 tags usage to make html output semantically correct

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -36,7 +36,7 @@
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // are there comments to navigate through ?>
 		<nav role="navigation" id="comment-nav-above" class="site-navigation comment-navigation">
-			<h1 class="assistive-text"><?php _e( 'Comment navigation', '_s' ); ?></h1>
+			<div class="assistive-text"><?php _e( 'Comment navigation', '_s' ); ?></div>
 			<div class="nav-previous"><?php previous_comments_link( __( '&larr; Older Comments', '_s' ) ); ?></div>
 			<div class="nav-next"><?php next_comments_link( __( 'Newer Comments &rarr;', '_s' ) ); ?></div>
 		</nav><!-- #comment-nav-before .site-navigation .comment-navigation -->
@@ -56,7 +56,7 @@
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // are there comments to navigate through ?>
 		<nav role="navigation" id="comment-nav-below" class="site-navigation comment-navigation">
-			<h1 class="assistive-text"><?php _e( 'Comment navigation', '_s' ); ?></h1>
+			<div class="assistive-text"><?php _e( 'Comment navigation', '_s' ); ?></div>
 			<div class="nav-previous"><?php previous_comments_link( __( '&larr; Older Comments', '_s' ) ); ?></div>
 			<div class="nav-next"><?php next_comments_link( __( 'Newer Comments &rarr;', '_s' ) ); ?></div>
 		</nav><!-- #comment-nav-below .site-navigation .comment-navigation -->

--- a/content-page.php
+++ b/content-page.php
@@ -9,7 +9,11 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
-		<h1 class="entry-title"><?php the_title(); ?></h1>
+		<?php if ( is_front_page() ) { ?>
+			<div class="entry-title"><?php the_title(); ?></div>
+		<?php } else { ?>
+			<h1 class="entry-title"><?php the_title(); ?></h1>
+		<?php } ?>
 	</header><!-- .entry-header -->
 
 	<div class="entry-content">

--- a/content.php
+++ b/content.php
@@ -7,7 +7,7 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
-		<h1 class="entry-title"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', '_s' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_title(); ?></a></h1>
+		<div class="entry-title"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', '_s' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_title(); ?></a></div>
 
 		<?php if ( 'post' == get_post_type() ) : ?>
 		<div class="entry-meta">

--- a/functions.php
+++ b/functions.php
@@ -90,8 +90,8 @@ function _s_widgets_init() {
 		'id' => 'sidebar-1',
 		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
 		'after_widget' => '</aside>',
-		'before_title' => '<h1 class="widget-title">',
-		'after_title' => '</h1>',
+		'before_title' => '<div class="widget-title">',
+		'after_title' => '</div>',
 	) );
 }
 add_action( 'widgets_init', '_s_widgets_init' );

--- a/header.php
+++ b/header.php
@@ -47,12 +47,17 @@
 	<?php do_action( 'before' ); ?>
 	<header id="masthead" class="site-header" role="banner">
 		<hgroup>
-			<h1 class="site-title"><a href="<?php echo home_url( '/' ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-			<h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
+			<?php if ( is_front_page() ) { ?>
+				<h1 class="site-title"><a href="<?php echo home_url( '/' ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+				<h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
+			<?php } else { ?>
+				<div class="site-title"><a href="<?php echo home_url( '/' ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></div>
+				<div class="site-description"><?php bloginfo( 'description' ); ?></div>
+			<?php } ?>
 		</hgroup>
 
 		<nav role="navigation" class="site-navigation main-navigation">
-			<h1 class="assistive-text"><?php _e( 'Menu', '_s' ); ?></h1>
+			<div class="assistive-text"><?php _e( 'Menu', '_s' ); ?></div>
 			<div class="assistive-text skip-link"><a href="#content" title="<?php esc_attr_e( 'Skip to content', '_s' ); ?>"><?php _e( 'Skip to content', '_s' ); ?></a></div>
 
 			<?php wp_nav_menu( array( 'theme_location' => 'primary' ) ); ?>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -23,7 +23,7 @@ function _s_content_nav( $nav_id ) {
 
 	?>
 	<nav role="navigation" id="<?php echo $nav_id; ?>" class="<?php echo $nav_class; ?>">
-		<h1 class="assistive-text"><?php _e( 'Post navigation', '_s' ); ?></h1>
+		<div class="assistive-text"><?php _e( 'Post navigation', '_s' ); ?></div>
 
 	<?php if ( is_single() ) : // navigation links for single posts ?>
 

--- a/sidebar.php
+++ b/sidebar.php
@@ -15,14 +15,14 @@
 				</aside>
 
 				<aside id="archives" class="widget">
-					<h1 class="widget-title"><?php _e( 'Archives', '_s' ); ?></h1>
+					<div class="widget-title"><?php _e( 'Archives', '_s' ); ?></div>
 					<ul>
 						<?php wp_get_archives( array( 'type' => 'monthly' ) ); ?>
 					</ul>
 				</aside>
 
 				<aside id="meta" class="widget">
-					<h1 class="widget-title"><?php _e( 'Meta', '_s' ); ?></h1>
+					<div class="widget-title"><?php _e( 'Meta', '_s' ); ?></div>
 					<ul>
 						<?php wp_register(); ?>
 						<li><?php wp_loginout(); ?></li>


### PR DESCRIPTION
Right now H1 tag is being abused and there are multiple instances of H1 on many pages, which is semantically incorrect, as every page can only have a single H1 tag.

I have changed the H1 tags usage so that they are output only once, as per the context and WordPress's `Frontpage settings` under `Reading` sub-settings section of `Settings`.

**What things are fixed?**
- Site title and description uses H1 & H2 tag only when on homepage
- Page / Post titles are H1 on their individual pages, and not on archive pages
- Assistive text are not H1 anymore
- Widget titles are not H1 anymore

Tested with WordPress defaults and custom settings for Frontpage display, and now this outputs optimal markup in terms of semantics.

Since this will make pages output semantically correct data, this will also help in improving SEO.
