### PR TITLE
Minor Change: removed wp tag in html comment

### DIFF
--- a/content-page.php
+++ b/content-page.php
@@ -17,4 +17,4 @@
 		<?php wp_link_pages( array( 'before' => '<div class="page-links">' . __( 'Pages:', '_s' ), 'after' => '</div>' ) ); ?>
 		<?php edit_post_link( __( 'Edit', '_s' ), '<span class="edit-link">', '</span>' ); ?>
 	</div><!-- .entry-content -->
-</article><!-- #post-<?php the_ID(); ?> -->
+</article><!-- #post-ID -->


### PR DESCRIPTION
The usage of a WordPress Tag within a html comment to identify a html end tag is a performance waste (needs to be rendered by PHP) and doesn't improve the readability of the code.
This applies to a couple of other templates, too.
