### PR TITLE
Supercharge _s's stylability with some additional conditional body classes.

### DIFF
--- a/inc/tweaks.php
+++ b/inc/tweaks.php
@@ -25,6 +25,58 @@ add_filter( 'wp_page_menu_args', '_s_page_menu_args' );
  * @since _s 1.0
  */
 function _s_body_classes( $classes ) {
+
+	// Grabs the $wp_query global var for use in post-/page-specific data
+	global $wp_query;
+
+	// Determine user's browser and adds appropriate class
+	global $is_lynx, $is_gecko, $is_IE, $is_opera, $is_NS4, $is_safari, $is_chrome, $is_iphone;
+	if		($is_lynx)		$classes[] = 'lynx';
+	elseif	($is_gecko)		$classes[] = 'gecko';
+	elseif	($is_opera)		$classes[] = 'opera';
+	elseif	($is_NS4)		$classes[] = 'ns4';
+	elseif	($is_safari)	$classes[] = 'safari';
+	elseif	($is_chrome)	$classes[] = 'chrome';
+	elseif	($is_IE)		$classes[] = 'ie';
+	elseif	($is_iphone)	$classes[] = 'iphone';
+	else					$classes[] = 'unknown-browser';
+
+	// Include user's IE version for version-specific hacking. Credit: http://wordpress.org/extend/plugins/krusty-msie-body-classes/
+	if( preg_match( '/MSIE ([0-9]+)([a-zA-Z0-9.]+)/', $_SERVER['HTTP_USER_AGENT'], $browser_version ) ){
+
+		// add a class with the major version number
+		$classes[] = 'ie' . $browser_version[1];
+
+		// add an ie-lt9 class to match MSIE 8 and older
+		if ( 9 > $browser_version[1] )
+			$classes[] = 'ie-lt9';
+
+		// add an ie-lt8 and ie-old class to match MSIE 7 and older
+		if ( 8 > $browser_version[1] ) {
+			$classes[] = 'ie-lt8';
+			$classes[] = 'ie-old';
+		}
+
+	}
+
+	// Adds post and page slug class, prefixed by 'post-' or 'page-', respectively
+	if ( is_single() )
+    	$classes[] = 'post-' . $wp_query->post->post_name;
+	elseif( is_page() )
+		$classes[] = 'page-' . $wp_query->post->post_name;
+
+	// Adds category classes for each category on single posts
+	if ( is_single() && $cats = get_the_category() )
+		foreach ( $cats as $cat )
+			$classes[] = 's-category-' . $cat->slug;
+
+	// Adds classes site-wide for the present year, month, day, and hour
+    $classes = array_merge( $classes, _s_date_classes() );
+
+	// Adds classes on single posts for the published year, month, day, and hour
+	if ( is_single() )
+		$classes = array_merge( $classes, _s_date_classes( mysql2date( 'U', $wp_query->post->post_date ), 's-' ) );
+
 	// Adds a class of group-blog to blogs with more than 1 published author
 	if ( is_multi_author() ) {
 		$classes[] = 'group-blog';
@@ -33,6 +85,33 @@ function _s_body_classes( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', '_s_body_classes' );
+
+/**
+ * Generates time- and date-based classes relative to GMT (UTC)
+ *
+ * @since Unknown
+ * @param int $time A UNIX timestamp (e.g. time())
+ * @param string $prefix Prefix to apply to the new class names
+ * @return array An array of date-based classes
+ */
+function _s_date_classes( $time = null, $prefix = null ) {
+
+	// If the $time var is empty, set it to the current time
+	$time = empty( $time ) ? time() : $time;
+
+	// Update our timestamp with the site's GMT offset
+	$time = $time + ( get_option('gmt_offset') * 3600 );
+
+	// Append a new class for each unit of time
+	$dates = array();
+	$dates[] = $prefix . 'y' . gmdate( 'Y', $time ); // Year
+	$dates[] = $prefix . 'm' . gmdate( 'm', $time ); // Month
+	$dates[] = $prefix . 'd' . gmdate( 'd', $time ); // Day
+	$dates[] = $prefix . 'h' . gmdate( 'H', $time ); // Hour
+
+	// Return our updated array
+	return $dates;
+}
 
 /**
  * Filter in a link to a content ID attribute for the next/previous image links on image attachment pages


### PR DESCRIPTION
Over the years I've found the conditional browser classes to be indespensible in theme development. When a particular browser is misbehaving it is extremely simple to conditionally alter a style (or fire some javascript) to handle its minor inconsistencies without having to load entirely separate stylesheets or conditional script files.

The post-/page-slug conditionals has also made it very easy to style a specific page/post on a dev server and have all the styles automatically match in production (in cases where a strict database export/import isn't used and post IDs change). It also makes it easier to read and write styles because a slug is more easily recognized than an arbitrary ID.

The category classes of course make it easier to style a site that uses thematically different categories (magazine style) and the date-based classes just allow for fun things like styling a site differently for Christmas or styling posts published in January in a way that separates them from posts published in otther times of the year.

The date-based classes require an additional function (_s_date_classes()). This functionality is probably superfluous for most sites, but is still a pretty clever trick and demo. Hat-tip to Ian and Themeatic for the inspiration behind this one… i think :)
