### PR TITLE
Deleted styling of obsolete tag <big>

### DIFF
--- a/style.css
+++ b/style.css
@@ -191,9 +191,6 @@ sub {
 small {
 	font-size: 75%;
 }
-big {
-	font-size: 125%;
-}
 figure {
 	margin: 0;
 }


### PR DESCRIPTION
According to http://www.w3.org/TR/html5-diff/#obsolete-elements HTML tag `<big>` is obsolete and hence shouldn't be styled.
