### PR TITLE
Fixed typos in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ If you want to set things up manually, download `_s` from github. The first thin
 
 OR
 
-* Search for: `_s` & replace with: `megatherium`
+* Search for: `'_s'` & replace with: `'megatherium'`
 * Search for: `_s_` & replace with: `megatherium_`
-* Search for: `_s` & replace with: `Megatherium`
+* Search for: ` _s` & replace with: ` Megatherium`
 
 Then, update the stylesheet header in style.css and the links in footer.php with your own information. Next, update or delete this readme.
 


### PR DESCRIPTION
I have fixed some typos in README.MD. This corrects how a user can find and replace theme name manually.
