### PR TITLE
Change .tag-links to .tags-links

### DIFF
--- a/content.php
+++ b/content.php
@@ -45,7 +45,7 @@
 				if ( $tags_list ) :
 			?>
 			<span class="sep"> | </span>
-			<span class="tag-links">
+			<span class="tags-links">
 				<?php printf( __( 'Tagged %1$s', '_s' ), $tags_list ); ?>
 			</span>
 			<?php endif; // End if $tags_list ?>


### PR DESCRIPTION
Using the class .tag-links may cause a rare formatting bug. To reproduce:
1. Publish a new post and tag it "links"
2. post_class() assigns the class .tag-links to the post
3. Any formatting applied to .tag-links in the theme's stylesheet will also apply to this post -- not good!

Changing the class name to something that won't conflict, like .tags-links, should solve this problem.
