### PR TITLE
Add a Post Format Archives heading to archive.php

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -46,7 +46,7 @@ get_header(); ?>
 								printf( __( 'Yearly Archives: %s', '_s' ), '<span>' . get_the_date( 'Y' ) . '</span>' );
 
 							} elseif ( get_post_format() ) {
-								printf( __( 'Post Format Archives: %s', '_s' ), '<span>' . get_post_format() . '</span>' );
+								printf( __( 'Post Format Archives: %s', '_s' ), '<span>' . get_post_format_string( get_post_format() ) . '</span>' );
 
 							} else {
 


### PR DESCRIPTION
When posts of a certain post format are viewed as an archive, the heading reads simply "Archives". For clarity, we could add a more specific heading for these types of archives, eg. "Post Format Archives: aside"
