### PR TITLE
Add max-width to select elements in widgets to prevent it overflowing from widget areas.

### DIFF
--- a/style.css
+++ b/style.css
@@ -545,6 +545,11 @@ object {
 	margin: 0 0 1.5em;
 }
 
+/* Make sure select elements fit in widgets */
+.widget select {
+	max-width: 100%;
+}
+
 /* Search widget */
 #searchsubmit {
 	display: none;


### PR DESCRIPTION
I find myself adding this frequently and I thought it could be useful to have in _s. 

This intends to fix a common issue - the dropdown in the category widget overflows when a blog has a long category name.
