### PR TITLE
Small typo in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you want to keep it simple, head over to http://underscores.me and generate y
 If you want to set things up manually, download `_s` from github. The first thing you want to do is copy the `_s` directory and change the name to something else — Like, say, `megatherium` — then you'll need to do a three-step find and replace on the name in all the templates.
 
 1. Search for `_s` inside single quotations to capture the text domain.
-2. Search for `_s_` for to capture all the function names
+2. Search for `_s_` to capture all the function names
 3. Search for `_s` with a space before it to replace all the occurrences of it in comments. (You'd replace this with the capitalized version of your theme name.)
 
 OR


### PR DESCRIPTION
Changed 

"Search for `_s_` for to capture all the function names"
to
"Search for `_s_` to capture all the function names"
