### PR TITLE
Use the section tag for #primary divs across all template files.

### DIFF
--- a/404.php
+++ b/404.php
@@ -8,7 +8,7 @@
 
 get_header(); ?>
 
-	<div id="primary" class="content-area">
+	<section id="primary" class="content-area">
 		<div id="content" class="site-content" role="main">
 
 			<article id="post-0" class="post error404 not-found">
@@ -42,6 +42,6 @@ get_header(); ?>
 			</article><!-- #post-0 .post .error404 .not-found -->
 
 		</div><!-- #content .site-content -->
-	</div><!-- #primary .content-area -->
+	</section><!-- #primary .content-area -->
 
 <?php get_footer(); ?>

--- a/image.php
+++ b/image.php
@@ -9,7 +9,7 @@
 get_header();
 ?>
 
-		<div id="primary" class="content-area image-attachment">
+		<section id="primary" class="content-area image-attachment">
 			<div id="content" class="site-content" role="main">
 
 			<?php while ( have_posts() ) : the_post(); ?>
@@ -106,6 +106,6 @@ get_header();
 			<?php endwhile; // end of the loop. ?>
 
 			</div><!-- #content .site-content -->
-		</div><!-- #primary .content-area .image-attachment -->
+		</section><!-- #primary .content-area .image-attachment -->
 
 <?php get_footer(); ?>

--- a/index.php
+++ b/index.php
@@ -14,7 +14,7 @@
 
 get_header(); ?>
 
-		<div id="primary" class="content-area">
+		<section id="primary" class="content-area">
 			<div id="content" class="site-content" role="main">
 
 			<?php if ( have_posts() ) : ?>
@@ -43,7 +43,7 @@ get_header(); ?>
 			<?php endif; ?>
 
 			</div><!-- #content .site-content -->
-		</div><!-- #primary .content-area -->
+		</section><!-- #primary .content-area -->
 
 <?php get_sidebar(); ?>
 <?php get_footer(); ?>

--- a/page.php
+++ b/page.php
@@ -13,7 +13,7 @@
 
 get_header(); ?>
 
-		<div id="primary" class="content-area">
+		<section id="primary" class="content-area">
 			<div id="content" class="site-content" role="main">
 
 				<?php while ( have_posts() ) : the_post(); ?>
@@ -25,7 +25,7 @@ get_header(); ?>
 				<?php endwhile; // end of the loop. ?>
 
 			</div><!-- #content .site-content -->
-		</div><!-- #primary .content-area -->
+		</section><!-- #primary .content-area -->
 
 <?php get_sidebar(); ?>
 <?php get_footer(); ?>

--- a/single.php
+++ b/single.php
@@ -8,7 +8,7 @@
 
 get_header(); ?>
 
-		<div id="primary" class="content-area">
+		<section id="primary" class="content-area">
 			<div id="content" class="site-content" role="main">
 
 			<?php while ( have_posts() ) : the_post(); ?>
@@ -28,7 +28,7 @@ get_header(); ?>
 			<?php endwhile; // end of the loop. ?>
 
 			</div><!-- #content .site-content -->
-		</div><!-- #primary .content-area -->
+		</section><!-- #primary .content-area -->
 
 <?php get_sidebar(); ?>
 <?php get_footer(); ?>


### PR DESCRIPTION
I don't see a reason to use `div` for some places and `section` for other places for the same `#primary` block. Is it because sections need titles? Why don't we use `section` everywhere instead? Consistent with search.php and archive.php.
