### PR TITLE
Searchfrom value is double escaped

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -8,6 +8,6 @@
 ?>
 	<form method="get" id="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>" role="search">
 		<label for="s" class="assistive-text"><?php _e( 'Search', '_s' ); ?></label>
-		<input type="text" class="field" name="s" value="<?php echo esc_attr( get_search_query() ); ?>" id="s" placeholder="<?php esc_attr_e( 'Search &hellip;', '_s' ); ?>" />
+		<input type="text" class="field" name="s" value="<?php echo get_search_query(); ?>" id="s" placeholder="<?php esc_attr_e( 'Search &hellip;', '_s' ); ?>" />
 		<input type="submit" class="submit" name="submit" id="searchsubmit" value="<?php esc_attr_e( 'Search', '_s' ); ?>" />
 	</form>


### PR DESCRIPTION
There is no need to esc_attr(get_search_query) since the default behavior of the function is already escaped.

``` php
/* See wp-includes/general-template.php, line 1827 */
function get_search_query( $escaped = true ) {
    $query = apply_filters( 'get_search_query', get_query_var( 's' ) );
    if ( $escaped )
        $query = esc_attr( $query );
    return $query;
}
```
