### PR TITLE
_s: Add additional Post Formats into functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -74,7 +74,7 @@ function _s_setup() {
 	/**
 	 * Add support for the Aside Post Formats
 	 */
-	add_theme_support( 'post-formats', array( 'aside', ) );
+	add_theme_support( 'post-formats', array( 'aside', 'image', 'video', 'quote', 'link' ) );
 }
 endif; // _s_setup
 add_action( 'after_setup_theme', '_s_setup' );


### PR DESCRIPTION
By default let's support the following Post Formats: Aside, Image, Video, Quote, and Link, to be in line with WordPress.com's (Insta)posting experience.
