### PR TITLE
Load comments template only when comments are open or there's at least one comment in image.php and page.php

### DIFF
--- a/image.php
+++ b/image.php
@@ -109,7 +109,11 @@ get_header();
 					</footer><!-- .entry-meta -->
 				</article><!-- #post-<?php the_ID(); ?> -->
 
-				<?php comments_template(); ?>
+				<?php
+					// If comments are open or we have at least one comment, load up the comment template
+					if ( comments_open() || '0' != get_comments_number() )
+						comments_template( '', true );
+				?>
 
 			<?php endwhile; // end of the loop. ?>
 

--- a/page.php
+++ b/page.php
@@ -20,7 +20,11 @@ get_header(); ?>
 
 					<?php get_template_part( 'content', 'page' ); ?>
 
-					<?php comments_template( '', true ); ?>
+          <?php
+            // If comments are open or we have at least one comment, load up the comment template
+            if ( comments_open() || '0' != get_comments_number() )
+              comments_template( '', true );
+          ?>
 
 				<?php endwhile; // end of the loop. ?>
 


### PR DESCRIPTION
To be consistent with single.php and to ensure that an empty div (#comments .comments-area) isn't outputted when both comments are closed and there aren't any comments.
