### PR TITLE
_s: Provide a context for the comments title strings.

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -29,7 +29,7 @@
 	<?php if ( have_comments() ) : ?>
 		<h2 class="comments-title">
 			<?php
-				printf( _n( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), '_s' ),
+				printf( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', '_s' ),
 					number_format_i18n( get_comments_number() ), '<span>' . get_the_title() . '</span>' );
 			?>
 		</h2>


### PR DESCRIPTION
There are languages that have more than one plural form. Sometimes these
languages need to add the %1$s placeholder in the original singular
version to help differentiate between these plural forms.

In case the original singular version ('One thought on
&ldquo;%2$s&rdquo;' in this case) is used elsewhere, the translation
with the faulty %1$s will be used, possibly ending up with the
placeholder not being replaced.

The context will prevent that from happening by seperating the strings.
