### PR TITLE
"Skip to content" link changes visual focus, but not input focus

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -103,6 +103,8 @@ function _s_scripts() {
 	wp_enqueue_style( 'style', get_stylesheet_uri() );
 
 	wp_enqueue_script( 'small-menu', get_template_directory_uri() . '/js/small-menu.js', array( 'jquery' ), '20120206', true );
+	
+	wp_enqueue_script( 'skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array( 'jquery' ), '20130115', true );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -1,0 +1,23 @@
+/**
+ * Based on JavaScript by Nicholas C. Zakas
+ * http://www.nczonline.net/blog/2013/01/15/fixing-skip-to-content-links/
+ */
+
+( function( $ ) {
+
+$( window ).bind( 'hashchange', function() {
+
+    var element = document.getElementById( location.hash.substring( 1 ) );
+
+    if ( element ) {
+
+        if ( ! /^(?:a|select|input|button)$/i.test( element.tagName ) ) {
+            element.tabIndex = -1;
+        }
+        
+        element.focus();
+    }
+
+});
+
+})( jQuery );


### PR DESCRIPTION
The problem is that when someone clicks a skip link, the viewport is scrolled to the #content, but pressing tab will bring focus to the site's main navigation. The expected behavior would be to select the first link in the #content, not the site's main navigation. Of course this is the browser's default behavior, and not really a _s bug, but it is an opportunity to make _s-based themes more accessible to users that navigate solely through keyboard input.

I learned about this issue via [an article written by Nicholas C. Zakas.](http://www.nczonline.net/blog/2013/01/15/fixing-skip-to-content-links/) He suggests setting focus to the #content using JavaScript. I've adapted his example to use jQuery and to better conform to [WordPress coding standards.](http://codex.wordpress.org/WordPress_Coding_Standards)
