### PR TITLE
make "Skip to content" link work in browsers that are doing_it_wrong, but without jQuery

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -104,6 +104,8 @@ function _s_scripts() {
 
 	wp_enqueue_script( 'small-menu', get_template_directory_uri() . '/js/small-menu.js', array( 'jquery' ), '20120206', true );
 
+    wp_enqueue_script( 'skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array( ), '20130115', true );
+
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );
 	}

--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -1,0 +1,25 @@
+( function() {
+var is_webkit = navigator.userAgent.toLowerCase().indexOf('webkit') > -1;
+var is_opera = navigator.userAgent.toLowerCase().indexOf('opera') > -1;
+var is_ie = navigator.userAgent.toLowerCase().indexOf('msie') > -1;
+
+if((is_webkit || is_opera || is_ie ) &&  typeof(document.getElementById) !== 'undefined'  ) {
+    var eventMethod = (window.addEventListener) ? 'addEventListener' : 'attachEvent' ;
+    window[eventMethod]("hashchange", function(event) {
+
+        var element = document.getElementById(location.hash.substring(1));
+
+        if (element) {
+
+            if (!/^(?:a|select|input|button|textarea)$/i.test(element.tagName)) {
+                element.tabIndex = -1;
+            }
+
+            element.focus();
+        }
+
+    }, false); 
+
+} 
+
+})();


### PR DESCRIPTION
This is largely the same as #136, however it doesn't use jQuery. My thinking is people will be more inclined to keep it if there isn't a library requirement for it. 
