### PR TITLE
Update Theme URL

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: _s
-Theme URI: https://github.com/Automattic/_s/
+Theme URI: http://underscores.me
 Author: Automattic
 Author URI: http://automattic.com/
 Description: Hi. I'm a starter theme called <code>_s</code>, or <em>underscores</em>, if you like. I'm a theme meant for hacking so don't use me as a <em>Parent Theme</em>. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.


### PR DESCRIPTION
The Theme URL was previously pointing to an old Automattic svn repository that no longer exists. This change points the URL back to the main `_s` GitHub repository where it is now being developed on.  Alternatively it could point to underscores.me
