### PR TITLE
Remove reference to theme options in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ My ultra-minimal CSS might make me look like theme tartare but that means less s
 * A helpful 404 template.
 * A sample custom header implementation in inc/custom-header.php that can be activated by uncommenting one line in functions.php and adding the code snippet found the comments of inc/custom-header.php to your header.php template.
 * Custom template tags in inc/template-tags that keep your templates clean and neat and prevent code duplication.
-* Sample theme options in /inc/theme-options/ that can be activated by uncommenting one line in functions.php.
 * Some small tweaks in /inc/tweaks.php that can improve your theming experience. They can be activated by uncommenting one line in functions.php.
 * Keyboard navigation for image attachment templates. The script can be found in js/keyboard-navigation.js. It’s enqueued in functions.php.
 * A script at js/small-menu.js that makes your menu a toggled dropdown on small screens (like your phone), ready for CSS artistry. It’s enqueued in functions.php.


### PR DESCRIPTION
Looks like the theme options file was removed at some point, but not from the readme.

This is causing some confusion for Ruben: http://wordpress.org/support/topic/theme-_s-how-to-set-up-correct-theme-options-framework
