### PR TITLE
content-page.php, taking 'Edit' link outside .entry-content

### DIFF
--- a/content-page.php
+++ b/content-page.php
@@ -15,6 +15,6 @@
 	<div class="entry-content">
 		<?php the_content(); ?>
 		<?php wp_link_pages( array( 'before' => '<div class="page-links">' . __( 'Pages:', '_s' ), 'after' => '</div>' ) ); ?>
-		<?php edit_post_link( __( 'Edit', '_s' ), '<span class="edit-link">', '</span>' ); ?>
 	</div><!-- .entry-content -->
+	<?php edit_post_link( __( 'Edit', '_s' ), '<footer class="entry-meta"><span class="edit-link">', '</span></footer>' ); ?>
 </article><!-- #post-<?php the_ID(); ?> -->


### PR DESCRIPTION
In content-page.php, taking 'Edit' link outside .entry-content and putting it inside footer.entry-meta so that styling is consistent with single posts.
