### PR TITLE
$nav_id comes from outside, should be escaped.

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -17,6 +17,9 @@ if ( ! function_exists( '_s_content_nav' ) ) :
 function _s_content_nav( $nav_id ) {
 	global $wp_query, $post;
 
+	// $nav_id comes from outside, so this variable should be escaped.
+	$nav_id = esc_attr( $nav_id );
+
 	// Don't print empty markup on single pages if there's nowhere to navigate.
 	if ( is_single() ) {
 		$previous = ( is_attachment() ) ? get_post( $post->post_parent ) : get_adjacent_post( false, '', true );


### PR DESCRIPTION
$nav_id comes from outside, so this variable should be escaped.

Same defect found on TwentyTwelve theme. (TwentyTwelve theme is already fixed.)
https://core.trac.wordpress.org/ticket/22690
