### PR TITLE
Adding main element as a block element

### DIFF
--- a/style.css
+++ b/style.css
@@ -57,6 +57,7 @@ figure,
 footer,
 header,
 hgroup,
+main,
 nav,
 section {
 	display: block;


### PR DESCRIPTION
Per http://www.w3.org/TR/2012/WD-html-main-element-20121217/ the
element main should be included to display it as a block element.
