### PR TITLE
Force External Links to Open in a New Window

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -14,9 +14,9 @@
 	<footer id="colophon" class="site-footer" role="contentinfo">
 		<div class="site-info">
 			<?php do_action( '_s_credits' ); ?>
-			<a href="http://wordpress.org/" title="<?php esc_attr_e( 'A Semantic Personal Publishing Platform', '_s' ); ?>" rel="generator"><?php printf( __( 'Proudly powered by %s', '_s' ), 'WordPress' ); ?></a>
+			<a href="http://wordpress.org/" title="<?php esc_attr_e( 'A Semantic Personal Publishing Platform', '_s' ); ?>" rel="generator" target="_blank"><?php printf( __( 'Proudly powered by %s', '_s' ), 'WordPress' ); ?></a>
 			<span class="sep"> | </span>
-			<?php printf( __( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="http://automattic.com/" rel="designer">Automattic</a>' ); ?>
+			<?php printf( __( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="http://automattic.com/" rel="designer" target="_blank">Automattic</a>' ); ?>
 		</div><!-- .site-info -->
 	</footer><!-- #colophon .site-footer -->
 </div><!-- #page .hfeed .site -->


### PR DESCRIPTION
It seems to me that it has been convention to open up external links in a new window for a while now.

[Recent articles](http://uxmovement.com/navigation/why-external-links-should-open-in-new-tabs/) indicate that it is easier for a user to navigate around an external website and then return to the original website by deleting the tab.

Most of the articles stating _Never Ever Open Websites In New Windows_ were written before tabs were popular.
