### PR TITLE
Remove vendor prefixes on box-shadow.

### DIFF
--- a/style.css
+++ b/style.css
@@ -218,7 +218,6 @@ textarea {
 button,
 input {
 	line-height: normal; /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
-	*overflow: visible;  /* Corrects inner spacing displayed oddly in IE6/7 */
 }
 button,
 html input[type="button"],
@@ -336,7 +335,6 @@ a:active {
 
 /* Text meant only for screen readers */
 .assistive-text {
-	clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
 	clip: rect(1px, 1px, 1px, 1px);
 	position: absolute !important;
 }


### PR DESCRIPTION
Not needed except in rare cases where the user has an extremely outdated version of iOS safari.
