### PR TITLE
Ditch all @since DocBlocks from theme.

### DIFF
--- a/404.php
+++ b/404.php
@@ -3,7 +3,6 @@
  * The template for displaying 404 pages (Not Found).
  *
  * @package _s
- * @since _s 1.0
  */
 
 get_header(); ?>

--- a/archive.php
+++ b/archive.php
@@ -5,7 +5,6 @@
  * Learn more: http://codex.wordpress.org/Template_Hierarchy
  *
  * @package _s
- * @since _s 1.0
  */
 
 get_header(); ?>

--- a/comments.php
+++ b/comments.php
@@ -8,7 +8,6 @@
  * located in the inc/template-tags.php file.
  *
  * @package _s
- * @since _s 1.0
  */
 ?>
 

--- a/content-page.php
+++ b/content-page.php
@@ -3,7 +3,6 @@
  * The template used for displaying page content in page.php
  *
  * @package _s
- * @since _s 1.0
  */
 ?>
 

--- a/content-single.php
+++ b/content-single.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * @package _s
- * @since _s 1.0
  */
 ?>
 

--- a/content.php
+++ b/content.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * @package _s
- * @since _s 1.0
  */
 ?>
 

--- a/footer.php
+++ b/footer.php
@@ -5,7 +5,6 @@
  * Contains the closing of the id=main div and all content after
  *
  * @package _s
- * @since _s 1.0
  */
 ?>
 

--- a/functions.php
+++ b/functions.php
@@ -3,13 +3,10 @@
  * _s functions and definitions
  *
  * @package _s
- * @since _s 1.0
  */
 
 /**
  * Set the content width based on the theme's design and stylesheet.
- *
- * @since _s 1.0
  */
 if ( ! isset( $content_width ) )
 	$content_width = 640; /* pixels */
@@ -26,8 +23,6 @@ if ( ! function_exists( '_s_setup' ) ) :
  * Note that this function is hooked into the after_setup_theme hook, which runs
  * before the init hook. The init hook is too late for some features, such as indicating
  * support post thumbnails.
- *
- * @since _s 1.0
  */
 function _s_setup() {
 
@@ -117,8 +112,6 @@ add_action( 'after_setup_theme', '_s_register_custom_background' );
 
 /**
  * Register widgetized area and update sidebar with default widgets
- *
- * @since _s 1.0
  */
 function _s_widgets_init() {
 	register_sidebar( array(

--- a/header.php
+++ b/header.php
@@ -5,7 +5,6 @@
  * Displays all of the <head> section and everything up till <div id="main">
  *
  * @package _s
- * @since _s 1.0
  */
 ?><!DOCTYPE html>
 <html <?php language_attributes(); ?>>

--- a/image.php
+++ b/image.php
@@ -3,7 +3,6 @@
  * The template for displaying image attachments.
  *
  * @package _s
- * @since _s 1.0
  */
 
 get_header();

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -14,7 +14,6 @@
 
  *
  * @package _s
- * @since _s 1.0
  */
 
 /**
@@ -72,7 +71,6 @@ add_action( 'after_setup_theme', '_s_custom_header_setup' );
  * @return stdClass All properties represent attributes of the curent header image.
  *
  * @package _s
- * @since _s 1.1
  */
 
 if ( ! function_exists( 'get_custom_header' ) ) {
@@ -91,8 +89,6 @@ if ( ! function_exists( '_s_header_style' ) ) :
  * Styles the header image and text displayed on the blog
  *
  * @see _s_custom_header_setup().
- *
- * @since _s 1.0
  */
 function _s_header_style() {
 
@@ -132,8 +128,6 @@ if ( ! function_exists( '_s_admin_header_style' ) ) :
  * Styles the header image displayed on the Appearance > Header admin panel.
  *
  * @see _s_custom_header_setup().
- *
- * @since _s 1.0
  */
 function _s_admin_header_style() {
 ?>
@@ -162,8 +156,6 @@ if ( ! function_exists( '_s_admin_header_image' ) ) :
  * Custom header image markup displayed on the Appearance > Header admin panel.
  *
  * @see _s_custom_header_setup().
- *
- * @since _s 1.0
  */
 function _s_admin_header_image() { ?>
 	<div id="headimg">

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -3,15 +3,12 @@
  * _s Theme Customizer
  *
  * @package _s
- * @since _s 1.2
  */
 
 /**
  * Add postMessage support for site title and description for the Theme Customizer.
  *
  * @param WP_Customize_Manager $wp_customize Theme Customizer object.
- *
- * @since _s 1.2
  */
 function _s_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
@@ -22,8 +19,6 @@ add_action( 'customize_register', '_s_customize_register' );
 
 /**
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
- *
- * @since _s 1.2
  */
 function _s_customize_preview_js() {
 	wp_enqueue_script( '_s_customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), '20130304', true );

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -5,13 +5,10 @@
  * Eventually, some of the functionality here could be replaced by core features
  *
  * @package _s
- * @since _s 1.0
  */
 
 /**
  * Get our wp_nav_menu() fallback, wp_page_menu(), to show a home link.
- *
- * @since _s 1.0
  */
 function _s_page_menu_args( $args ) {
 	$args['show_home'] = true;
@@ -21,8 +18,6 @@ add_filter( 'wp_page_menu_args', '_s_page_menu_args' );
 
 /**
  * Adds custom classes to the array of body classes.
- *
- * @since _s 1.0
  */
 function _s_body_classes( $classes ) {
 	// Adds a class of group-blog to blogs with more than 1 published author
@@ -36,8 +31,6 @@ add_filter( 'body_class', '_s_body_classes' );
 
 /**
  * Filter in a link to a content ID attribute for the next/previous image links on image attachment pages
- *
- * @since _s 1.0
  */
 function _s_enhanced_image_navigation( $url, $id ) {
 	if ( ! is_attachment() && ! wp_attachment_is_image( $id ) )
@@ -53,8 +46,6 @@ add_filter( 'attachment_link', '_s_enhanced_image_navigation', 10, 2 );
 
 /**
  * Filters wp_title to print a neat <title> tag based on what is being viewed.
- *
- * @since _s 1.1
  */
 function _s_wp_title( $title, $sep ) {
 	global $page, $paged;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -5,14 +5,11 @@
  * Eventually, some of the functionality here could be replaced by core features
  *
  * @package _s
- * @since _s 1.0
  */
 
 if ( ! function_exists( '_s_content_nav' ) ) :
 /**
  * Display navigation to next/previous pages when applicable
- *
- * @since _s 1.0
  */
 function _s_content_nav( $nav_id ) {
 	global $wp_query, $post;
@@ -63,8 +60,6 @@ if ( ! function_exists( '_s_comment' ) ) :
  * Template for comments and pingbacks.
  *
  * Used as a callback by wp_list_comments() for displaying the comments.
- *
- * @since _s 1.0
  */
 function _s_comment( $comment, $args, $depth ) {
 	$GLOBALS['comment'] = $comment;
@@ -114,8 +109,6 @@ endif; // ends check for _s_comment()
 if ( ! function_exists( '_s_posted_on' ) ) :
 /**
  * Prints HTML with meta information for the current post-date/time and author.
- *
- * @since _s 1.0
  */
 function _s_posted_on() {
 	printf( __( 'Posted on <a href="%1$s" title="%2$s" rel="bookmark"><time class="entry-date" datetime="%3$s">%4$s</time></a><span class="byline"> by <span class="author vcard"><a class="url fn n" href="%5$s" title="%6$s" rel="author">%7$s</a></span></span>', '_s' ),
@@ -131,8 +124,6 @@ function _s_posted_on() {
 endif;
 /**
  * Returns true if a blog has more than 1 category
- *
- * @since _s 1.0
  */
 function _s_categorized_blog() {
 	if ( false === ( $all_the_cool_cats = get_transient( 'all_the_cool_cats' ) ) ) {
@@ -158,8 +149,6 @@ function _s_categorized_blog() {
 
 /**
  * Flush out the transients used in _s_categorized_blog
- *
- * @since _s 1.0
  */
 function _s_category_transient_flusher() {
 	// Like, beat it. Dig?

--- a/inc/wpcom.php
+++ b/inc/wpcom.php
@@ -3,7 +3,6 @@
  * WordPress.com-specific functions and definitions
  *
  * @package _s
- * @since _s 1.0
  */
 
 global $themecolors;
@@ -12,7 +11,6 @@ global $themecolors;
  * Set a default theme color array for WP.com.
  *
  * @global array $themecolors
- * @since _s 1.0
  */
 $themecolors = array(
 	'bg'     => '',

--- a/index.php
+++ b/index.php
@@ -9,7 +9,6 @@
  * Learn more: http://codex.wordpress.org/Template_Hierarchy
  *
  * @package _s
- * @since _s 1.0
  */
 
 get_header(); ?>

--- a/no-results.php
+++ b/no-results.php
@@ -5,7 +5,6 @@
  * Learn more: http://codex.wordpress.org/Template_Hierarchy
  *
  * @package _s
- * @since _s 1.0
  */
 ?>
 

--- a/page.php
+++ b/page.php
@@ -8,7 +8,6 @@
  * different template.
  *
  * @package _s
- * @since _s 1.0
  */
 
 get_header(); ?>

--- a/search.php
+++ b/search.php
@@ -3,7 +3,6 @@
  * The template for displaying Search Results pages.
  *
  * @package _s
- * @since _s 1.0
  */
 
 get_header(); ?>

--- a/searchform.php
+++ b/searchform.php
@@ -3,7 +3,6 @@
  * The template for displaying search forms in _s
  *
  * @package _s
- * @since _s 1.0
  */
 ?>
 	<form method="get" id="searchform" class="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>" role="search">

--- a/sidebar.php
+++ b/sidebar.php
@@ -3,7 +3,6 @@
  * The Sidebar containing the main widget areas.
  *
  * @package _s
- * @since _s 1.0
  */
 ?>
 	<div id="secondary" class="widget-area" role="complementary">

--- a/single.php
+++ b/single.php
@@ -3,7 +3,6 @@
  * The Template for displaying all single posts.
  *
  * @package _s
- * @since _s 1.0
  */
 
 get_header(); ?>


### PR DESCRIPTION
@since as a DocBlock in _s doesn't make much sense and should be removed entirely from the theme. Reasons:
1. The DocBlock makes it hard to retrofit old themes to _s without going through the trouble of manually ditching each @since DocBlock
2. In practice new functions rarely, if ever, get added into the themes we're developing using _s and @since feels like unnecessary clutter.
3. @since _s 1.0 is unique to _s itself, and doesn't make sense in context with other themes. For example, '@since _s 1.2' in the Customizer makes sense for _s but when a new theme is spun off using _s, that version number loses meaning and needs a new version number for the theme that's being developed.
4. I'd prefer to look at _s as a non-versioned theme that keeps getting rolling updates to its V. 1.0.

I'm certain there are other good reasons to gut this, but my brain is failing me at the moment. I think the above three are more than adequate.
