### PR TITLE
Add browser (and system) classes to body

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -28,6 +28,97 @@ function _s_body_classes( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', '_s_body_classes' );
+/**
+ *  Adds browser classes
+ */
+
+function _s_browser_classes( $classes ) {
+	$browser = $_SERVER[ 'HTTP_USER_AGENT' ];
+
+	// Mac, PC ...or Linux
+	if ( preg_match( "/Mac/", $browser ) ){
+		$classes[] = 'mac';
+
+	} elseif ( preg_match( "/Windows/", $browser ) ){
+		$classes[] = 'windows';
+
+	} elseif ( preg_match( "/Linux/", $browser ) ) {
+		$classes[] = 'linux';
+
+	} else {
+		$classes[] = 'unknown-os';
+	}
+
+	// Checks browsers in this order: Chrome, Safari, Opera, MSIE, FF
+	if ( preg_match( "/Chrome/", $browser ) ) {
+		$classes[] = 'chrome';
+
+		if ( ( current_theme_supports( 'minorbrowserversion_all' )) || ( current_theme_supports( 'minorbrowserversion_ch' ) ) ) {
+			preg_match( "/Chrome\/(\d+.\d+)/si", $browser, $matches );
+			$ch_version = 'ch' . str_replace( '.', '-', $matches[1] );
+		} else {
+			preg_match( "/Chrome\/(\d+)/si", $browser, $matches );
+			$ch_version = 'ch' . $matches[1];
+		}      
+		$classes[] = $ch_version;
+
+	} elseif ( preg_match( "/Safari/", $browser ) ) {
+		$classes[] = 'safari';
+
+		if ( ( current_theme_supports( 'minorbrowserversion_all' )) || ( current_theme_supports( 'minorbrowserversion_sf' ) ) ) {
+			preg_match( "/Version\/(\d+.\d+)/si", $browser, $matches );
+			$sf_version = 'sf' . str_replace( '.', '-', $matches[1] );
+		} else {
+			preg_match( "/Version\/(\d+)/si", $browser, $matches );
+			$sf_version = 'sf' . $matches[1];
+
+		}     
+		$classes[] = $sf_version;
+
+	} elseif ( preg_match( "/Opera/", $browser ) ) {
+		$classes[] = 'opera';
+
+		if ( ( current_theme_supports( 'minorbrowserversion_all' ) ) || ( current_theme_supports( 'minorbrowserversion_op' ) ) ) {
+			preg_match( "/Version\/(\d+.\d+)/si", $browser, $matches );
+			$op_version = 'op' . str_replace( '.', '-', $matches[1] );      
+		} else {
+			preg_match( "/Version\/(\d+)/si", $browser, $matches );
+			$op_version = 'op' . $matches[1];      			
+		}
+		$classes[] = $op_version;
+
+	} elseif ( preg_match( "/MSIE/", $browser ) ) {
+		$classes[] = 'msie';
+
+		if ( ( current_theme_supports( 'minorbrowserversion_all' )) || ( current_theme_supports( 'minorbrowserversion_ie' ) ) ) {
+			preg_match( "/MSIE (\d+.\d+)/si", $browser, $matches );
+			$ie_version = 'ie' . str_replace( '.', '-', $matches[1] );
+		} else {
+			preg_match( "/MSIE (\d+)/si", $browser, $matches );
+			$ie_version = 'ie' . $matches[1];
+
+		}
+		$classes[] = $ie_version;
+
+	} elseif ( preg_match( "/Firefox/", $browser ) && preg_match( "/Gecko/", $browser ) ) {
+			$classes[] = 'firefox';
+
+			if ( ( current_theme_supports( 'minorbrowserversion_all' ) ) || ( current_theme_supports( 'minorbrowserversion_ff' ) ) ) {
+				preg_match( "/Firefox\/(\d+.\d+)/si", $browser, $matches );
+				$ff_version = 'ff' . str_replace( '.', '-', $matches[1] );
+			} else {
+				preg_match( "/Firefox\/(\d+)/si", $browser, $matches );
+				$ff_version = 'ff' . $matches[1];
+			}      
+			$classes[] = $ff_version;
+
+	} else {
+		$classes[] = 'unknown-browser';
+	}
+	// return the $classes array
+	return $classes;
+} 
+add_filter( 'body_class', '_s_browser_classes' );
 
 /**
  * Filter in a link to a content ID attribute for the next/previous image links on image attachment pages


### PR DESCRIPTION
Add browser (and system) classes support in extras.php

I found out this when i wanted to target IE10 correctly. Currently, IE10 is ditching support of targeting with <!-- if ie --> and this is currently best CSS way to target IE10.
