### PR TITLE
Turn post thumbnail support off by default

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -61,9 +61,8 @@ function _s_setup() {
 
 	/**
 	 * Enable support for Post Thumbnails on posts and pages
-	 * For post-only support, use add_theme_support( 'post-thumbnails', array( 'post' ) );
-	 * For page-only support, use add_theme_support( 'post-thumbnails', array( 'page' ) );
-	 * See http://codex.wordpress.org/Function_Reference/add_theme_support#Post_Thumbnails
+	 *
+	 * @link http://codex.wordpress.org/Function_Reference/add_theme_support#Post_Thumbnails
 	 */
 	//add_theme_support( 'post-thumbnails' );
 


### PR DESCRIPTION
I'd like us to turn post thumbnail support off by default, as it's used nowhere in the theme by default. I'd also like to add a DocBlock into the theme which gives more information on post thumbnail support implementation.

What do you think?
