### PR TITLE
Remove `the_title_attribute` title attributes where it duplicates `the_title` in anchor text.

### DIFF
--- a/content.php
+++ b/content.php
@@ -6,8 +6,8 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
-		<h1 class="entry-title"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', '_s' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_title(); ?></a></h1>
-
+		<h1 class="entry-title"><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h1>
+		
 		<?php if ( 'post' == get_post_type() ) : ?>
 		<div class="entry-meta">
 			<?php _s_posted_on(); ?>


### PR DESCRIPTION
See http://core.trac.wordpress.org/ticket/24203 for the full discussion about this. I was only able to spot one instance of this in _s but I could totally be wrong here. Let me know if you spot any other issues and we'll take care of them ASAP.
