### PR TITLE
Minor minor issue in comments.php

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -36,7 +36,7 @@ if ( post_password_required() )
 			<h1 class="screen-reader-text"><?php _e( 'Comment navigation', '_s' ); ?></h1>
 			<div class="nav-previous"><?php previous_comments_link( __( '&larr; Older Comments', '_s' ) ); ?></div>
 			<div class="nav-next"><?php next_comments_link( __( 'Newer Comments &rarr;', '_s' ) ); ?></div>
-		</nav><!-- #comment-nav-before -->
+		</nav><!-- #comment-nav-above -->
 		<?php endif; // check for comment navigation ?>
 
 		<ol class="comment-list">


### PR DESCRIPTION
Just noticed that the HTML comments in "comments.php" didn't line up. Referred to "comment-nav-before" when it should be "comment-nav-above".
