### PR TITLE
Rework Navigation Menu: Builds off pull request #239 for issue #200

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -4,10 +4,9 @@
  * Handles toggling the navigation menu for small screens.
  */
 ( function() {
-	var container = document.getElementById( 'site-navigation' ),
-		button,
-		menu;
+	var container, button, menu;
 
+	container = document.getElementById( 'site-navigation' )
 	if ( ! container )
 		return;
 
@@ -22,6 +21,9 @@
 		button.style.display = 'none';
 		return;
 	}
+
+	if ( -1 == menu.className.indexOf( 'nav-menu' ) )
+		menu.className += ' nav-menu';
 
 	button.onclick = function() {
 		if ( -1 != container.className.indexOf( 'toggled' ) )

--- a/style.css
+++ b/style.css
@@ -441,14 +441,9 @@ a:active {
 	cursor: pointer;
 }
 
-.main-small-navigation ul {
-	display: none;
-}
-
 @media screen and (max-width: 600px) {
 	.menu-toggle,
-	.navigation-main.toggled ul.menu,
-	.navigation-main.toggled div.menu > ul {
+	.navigation-main.toggled-on .nav-menu {
 		display: block;
 	}
 


### PR DESCRIPTION
In this changeset:
- Only set button and menu if container is not null.
- Break up the "return early" conditional into multiple parts.
- Shorten the name of the toggled class from `toggled-on` to `toggled`.
- Restore the "Hide menu toggle button if menu is empty." documentation.
- Remove the `nav-menu` class. The previous code would replace any custom custom classes applied via `wp_nav_menu()` or template file.
- Replace the `nav-menu` selector is style.css with selectors that will target both a custom nav menu and a page menu. These changes could use critical feedback. Do you know of an edge case where they might not work as expected?
