### PR TITLE
.main-small-navigation ul for .sub-menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -447,6 +447,7 @@ a:active {
 
 @media screen and (max-width: 600px) {
 	.menu-toggle,
+	.main-small-navigation ul,
 	.main-small-navigation ul.nav-menu.toggled-on {
 		display: block;
 	}


### PR DESCRIPTION
.main-small-navigation ul is needed for custom menus, otherwise there will be no .sub-menu items (children) only parent items are showing.
