### PR TITLE
Search button trailing single-quote

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -10,5 +10,5 @@
 		<span class="screen-reader-text"><?php _ex( 'Search for:', 'label', '_s' ); ?></span>
 		<input type="search" class="search-field" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', '_s' ); ?>" value="<?php echo esc_attr( get_search_query() ); ?>" name="s" title="<?php _ex( 'Search for:', 'label', '_s' ); ?>" />
 	</label>
-	<input type="submit" class="search-submit" value="<?php echo esc_attr_x( 'Search', 'submit button', '_s' ); ?>'" />
+	<input type="submit" class="search-submit" value="<?php echo esc_attr_x( 'Search', 'submit button', '_s' ); ?>" />
 </form>


### PR DESCRIPTION
A trailing singe-quote has found its way into the search button value,
resulting in the button displaying "Search'" instead of "Search".
