### PR TITLE
Switch "navigation-" back to "-navigation"

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -32,7 +32,7 @@ if ( post_password_required() )
 		</h2>
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // are there comments to navigate through ?>
-		<nav id="comment-nav-above" class="navigation-comment" role="navigation">
+		<nav id="comment-nav-above" class="comment-navigation" role="navigation">
 			<h1 class="screen-reader-text"><?php _e( 'Comment navigation', '_s' ); ?></h1>
 			<div class="nav-previous"><?php previous_comments_link( __( '&larr; Older Comments', '_s' ) ); ?></div>
 			<div class="nav-next"><?php next_comments_link( __( 'Newer Comments &rarr;', '_s' ) ); ?></div>
@@ -52,7 +52,7 @@ if ( post_password_required() )
 		</ol><!-- .comment-list -->
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // are there comments to navigate through ?>
-		<nav id="comment-nav-below" class="navigation-comment" role="navigation">
+		<nav id="comment-nav-below" class="comment-navigation" role="navigation">
 			<h1 class="screen-reader-text"><?php _e( 'Comment navigation', '_s' ); ?></h1>
 			<div class="nav-previous"><?php previous_comments_link( __( '&larr; Older Comments', '_s' ) ); ?></div>
 			<div class="nav-next"><?php next_comments_link( __( 'Newer Comments &rarr;', '_s' ) ); ?></div>

--- a/image.php
+++ b/image.php
@@ -35,7 +35,7 @@ get_header();
 						?>
 					</div><!-- .entry-meta -->
 
-					<nav role="navigation" id="image-navigation" class="navigation-image">
+					<nav role="navigation" id="image-navigation" class="image-navigation">
 						<div class="nav-previous"><?php previous_image_link( false, __( '<span class="meta-nav">&larr;</span> Previous', '_s' ) ); ?></div>
 						<div class="nav-next"><?php next_image_link( false, __( 'Next <span class="meta-nav">&rarr;</span>', '_s' ) ); ?></div>
 					</nav><!-- #image-navigation -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -27,7 +27,7 @@ function _s_content_nav( $nav_id ) {
 	if ( $wp_query->max_num_pages < 2 && ( is_home() || is_archive() || is_search() ) )
 		return;
 
-	$nav_class = ( is_single() ) ? 'navigation-post' : 'navigation-paging';
+	$nav_class = ( is_single() ) ? 'post-navigation' : 'paging-navigation';
 
 	?>
 	<nav role="navigation" id="<?php echo esc_attr( $nav_id ); ?>" class="<?php echo $nav_class; ?>">

--- a/style.css
+++ b/style.css
@@ -589,7 +589,7 @@ object {
 ----------------------------------------------- */
 
 /* Globally hidden elements when Infinite Scroll is supported and in use. */
-.infinite-scroll .navigation-paging, /* Older / Newer Posts Navigation (always hidden) */
+.infinite-scroll .paging-navigation, /* Older / Newer Posts Navigation (always hidden) */
 .infinite-scroll.neverending .site-footer { /* Theme Footer (when set to scrolling) */
 	display: none;
 }


### PR DESCRIPTION
Original edit not needed for `[class*="navigation"]` selector. Matches
other class/id navigation naming conventions.
