### PR TITLE
Wrap translatable strings with HTML in them in wp_kses()

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -28,7 +28,7 @@ get_header(); ?>
 							 * what author we're dealing with (if that is the case).
 							*/
 							the_post();
-							printf( __( 'Author: %s', '_s' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" title="' . esc_attr( get_the_author() ) . '" rel="me">' . get_the_author() . '</a></span>' );
+							printf( wp_kses( __( 'Author: %s', '_s' ), array( 'span' => 'class', 'a' => array( 'class', 'href', 'title', 'rel' ) ) ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" title="' . esc_attr( get_the_author() ) . '" rel="me">' . get_the_author() . '</a></span>' );
 							/* Since we called the_post() above, we need to
 							 * rewind the loop back to the beginning that way
 							 * we can run the loop properly, in full.
@@ -36,13 +36,13 @@ get_header(); ?>
 							rewind_posts();
 
 						elseif ( is_day() ) :
-							printf( __( 'Day: %s', '_s' ), '<span>' . get_the_date() . '</span>' );
+							printf( wp_kses( __( 'Day: %s', '_s' ), array( 'span' ) ), '<span>' . get_the_date() . '</span>' );
 
 						elseif ( is_month() ) :
-							printf( __( 'Month: %s', '_s' ), '<span>' . get_the_date( 'F Y' ) . '</span>' );
+							printf( wp_kses( __( 'Month: %s', '_s' ), array( 'span' ) ), '<span>' . get_the_date( 'F Y' ) . '</span>' );
 
 						elseif ( is_year() ) :
-							printf( __( 'Year: %s', '_s' ), '<span>' . get_the_date( 'Y' ) . '</span>' );
+							printf( wp_kses( __( 'Year: %s', '_s' ), array( 'span' ) ), '<span>' . get_the_date( 'Y' ) . '</span>' );
 
 						elseif ( is_tax( 'post_format', 'post-format-aside' ) ) :
 							_e( 'Asides', '_s' );

--- a/content-single.php
+++ b/content-single.php
@@ -34,7 +34,7 @@
 			if ( ! _s_categorized_blog() ) {
 				// This blog only has 1 category so we just need to worry about tags in the meta text
 				if ( '' != $tag_list ) {
-					$meta_text = __( 'This entry was tagged %2$s. Bookmark the <a href="%3$s" title="Permalink to %4$s" rel="bookmark">permalink</a>.', '_s' );
+					$meta_text = wp_kses( __( 'This entry was tagged %2$s. Bookmark the <a href="%3$s" title="Permalink to %4$s" rel="bookmark">permalink</a>.', '_s' ), array( 'a' => array( 'href', 'rel', 'title' ) ) );
 				} else {
 					$meta_text = __( 'Bookmark the <a href="%3$s" title="Permalink to %4$s" rel="bookmark">permalink</a>.', '_s' );
 				}
@@ -42,9 +42,9 @@
 			} else {
 				// But this blog has loads of categories so we should probably display them here
 				if ( '' != $tag_list ) {
-					$meta_text = __( 'This entry was posted in %1$s and tagged %2$s. Bookmark the <a href="%3$s" title="Permalink to %4$s" rel="bookmark">permalink</a>.', '_s' );
+					$meta_text = wp_kses( __( 'This entry was posted in %1$s and tagged %2$s. Bookmark the <a href="%3$s" title="Permalink to %4$s" rel="bookmark">permalink</a>.', '_s' ), array( 'a' => array( 'href', 'title', 'rel' ) ) );
 				} else {
-					$meta_text = __( 'This entry was posted in %1$s. Bookmark the <a href="%3$s" title="Permalink to %4$s" rel="bookmark">permalink</a>.', '_s' );
+					$meta_text = wp_kses( __( 'This entry was posted in %1$s. Bookmark the <a href="%3$s" title="Permalink to %4$s" rel="bookmark">permalink</a>.', '_s' ), array( 'a' => array( 'href', 'title', 'rel' ) ) );
 				}
 
 			} // end check for categories on this blog

--- a/content.php
+++ b/content.php
@@ -21,7 +21,7 @@
 	</div><!-- .entry-summary -->
 	<?php else : ?>
 	<div class="entry-content">
-		<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', '_s' ) ); ?>
+		<?php the_content( wp_kses( __( 'Continue reading <span class="meta-nav">&rarr;</span>', '_s' ), array( 'span' => 'class' ) ) ); ?>
 		<?php
 			wp_link_pages( array(
 				'before' => '<div class="page-links">' . __( 'Pages:', '_s' ),

--- a/footer.php
+++ b/footer.php
@@ -15,7 +15,7 @@
 			<?php do_action( '_s_credits' ); ?>
 			<a href="http://wordpress.org/" title="<?php esc_attr_e( 'A Semantic Personal Publishing Platform', '_s' ); ?>" rel="generator"><?php printf( __( 'Proudly powered by %s', '_s' ), 'WordPress' ); ?></a>
 			<span class="sep"> | </span>
-			<?php printf( __( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="http://automattic.com/" rel="designer">Automattic</a>' ); ?>
+			<?php printf( wp_kses( __( 'Theme: %1$s by %2$s.', '_s' ), array( 'a' => array( 'href', 'rel' ) ) ), '_s', '<a href="http://automattic.com/" rel="designer">Automattic</a>' ); ?>
 		</div><!-- .site-info -->
 	</footer><!-- #colophon -->
 </div><!-- #page -->

--- a/image.php
+++ b/image.php
@@ -20,7 +20,11 @@ get_header();
 					<div class="entry-meta">
 						<?php
 							$metadata = wp_get_attachment_metadata();
-							printf( __( 'Published <span class="entry-date"><time class="entry-date" datetime="%1$s">%2$s</time></span> at <a href="%3$s" title="Link to full-size image">%4$s &times; %5$s</a> in <a href="%6$s" title="Return to %7$s" rel="gallery">%8$s</a>', '_s' ),
+							printf( wp_kses( __( 'Published <span class="entry-date"><time class="entry-date" datetime="%1$s">%2$s</time></span> at <a href="%3$s" title="Link to full-size image">%4$s &times; %5$s</a> in <a href="%6$s" title="Return to %7$s" rel="gallery">%8$s</a>', '_s' ), array(
+									'span' => 'class',
+									'time' => array( 'class', 'datetime' ),
+									'a'    => array( 'href', 'title', 'rel' )
+								) ),
 								esc_attr( get_the_date( 'c' ) ),
 								esc_html( get_the_date() ),
 								esc_url( wp_get_attachment_url() ),
@@ -36,8 +40,8 @@ get_header();
 					</div><!-- .entry-meta -->
 
 					<nav role="navigation" id="image-navigation" class="image-navigation">
-						<div class="nav-previous"><?php previous_image_link( false, __( '<span class="meta-nav">&larr;</span> Previous', '_s' ) ); ?></div>
-						<div class="nav-next"><?php next_image_link( false, __( 'Next <span class="meta-nav">&rarr;</span>', '_s' ) ); ?></div>
+						<div class="nav-previous"><?php previous_image_link( false, wp_kses( __( '<span class="meta-nav">&larr;</span> Previous', '_s' ), array( 'span' => 'class' ) ) ); ?></div>
+						<div class="nav-next"><?php next_image_link( false, wp_kses( __( 'Next <span class="meta-nav">&rarr;</span>', '_s' ), array( 'span' => 'class' ) ) ); ?></div>
 					</nav><!-- #image-navigation -->
 				</header><!-- .entry-header -->
 
@@ -66,11 +70,11 @@ get_header();
 				<footer class="entry-meta">
 					<?php
 						if ( comments_open() && pings_open() ) : // Comments and trackbacks open
-							printf( __( '<a class="comment-link" href="#respond" title="Post a comment">Post a comment</a> or leave a trackback: <a class="trackback-link" href="%s" title="Trackback URL for your post" rel="trackback">Trackback URL</a>.', '_s' ), esc_url( get_trackback_url() ) );
+							printf( wp_kses( __( '<a class="comment-link" href="#respond" title="Post a comment">Post a comment</a> or leave a trackback: <a class="trackback-link" href="%s" title="Trackback URL for your post" rel="trackback">Trackback URL</a>.', '_s' ), array( 'a' => array( 'class', 'href', 'title', 'rel' ) ) ), esc_url( get_trackback_url() ) );
 						elseif ( ! comments_open() && pings_open() ) : // Only trackbacks open
-							printf( __( 'Comments are closed, but you can leave a trackback: <a class="trackback-link" href="%s" title="Trackback URL for your post" rel="trackback">Trackback URL</a>.', '_s' ), esc_url( get_trackback_url() ) );
+							printf( wp_kses( __( 'Comments are closed, but you can leave a trackback: <a class="trackback-link" href="%s" title="Trackback URL for your post" rel="trackback">Trackback URL</a>.', '_s' ), array( 'a' => array( 'class', 'href', 'title', 'rel' ) ) ), esc_url( get_trackback_url() ) );
 						elseif ( comments_open() && ! pings_open() ) : // Only comments open
-							 _e( 'Trackbacks are closed, but you can <a class="comment-link" href="#respond" title="Post a comment">post a comment</a>.', '_s' );
+							 wp_kses( _e( 'Trackbacks are closed, but you can <a class="comment-link" href="#respond" title="Post a comment">post a comment</a>.', '_s' ), array( 'a' => array( 'class', 'href', 'title' ) ) );
 						elseif ( ! comments_open() && ! pings_open() ) : // Comments and trackbacks closed
 							_e( 'Both comments and trackbacks are currently closed.', '_s' );
 						endif;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -41,11 +41,11 @@ function _s_content_nav( $nav_id ) {
 	<?php elseif ( $wp_query->max_num_pages > 1 && ( is_home() || is_archive() || is_search() ) ) : // navigation links for home, archive, and search pages ?>
 
 		<?php if ( get_next_posts_link() ) : ?>
-		<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ) ); ?></div>
+		<div class="nav-previous"><?php next_posts_link( wp_kses( __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ), array( 'span' => 'class' ) ) ); ?></div>
 		<?php endif; ?>
 
 		<?php if ( get_previous_posts_link() ) : ?>
-		<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ) ); ?></div>
+		<div class="nav-next"><?php previous_posts_link( wp_kses( __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ), array( 'span' => 'class' ) ) ); ?></div>
 		<?php endif; ?>
 
 	<?php endif; ?>
@@ -78,7 +78,7 @@ function _s_comment( $comment, $args, $depth ) {
 			<footer class="comment-meta">
 				<div class="comment-author vcard">
 					<?php if ( 0 != $args['avatar_size'] ) echo get_avatar( $comment, $args['avatar_size'] ); ?>
-					<?php printf( __( '%s <span class="says">says:</span>', '_s' ), sprintf( '<cite class="fn">%s</cite>', get_comment_author_link() ) ); ?>
+					<?php printf( wp_kses( __( '%s <span class="says">says:</span>', '_s' ), array( 'cite' => 'class' ) ), sprintf( '<cite class="fn">%s</cite>', get_comment_author_link() ) ); ?>
 				</div><!-- .comment-author -->
 
 				<div class="comment-metadata">
@@ -177,7 +177,11 @@ function _s_posted_on() {
 		esc_html( get_the_modified_date() )
 	);
 
-	printf( __( '<span class="posted-on">Posted on %1$s</span><span class="byline"> by %2$s</span>', '_s' ),
+	printf( wp_kses( __( '<span class="posted-on">Posted on %1$s</span><span class="byline"> by %2$s</span>', '_s' ), array(
+				'span' => array( 'class' ),
+				'a'    => array( 'class', 'href', 'rel', 'title' ),
+				'time' => array( 'class', 'datetime' )
+		) ),
 		sprintf( '<a href="%1$s" title="%2$s" rel="bookmark">%3$s</a>',
 			esc_url( get_permalink() ),
 			esc_attr( get_the_time() ),

--- a/no-results.php
+++ b/no-results.php
@@ -16,7 +16,7 @@
 	<div class="page-content">
 		<?php if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-			<p><?php printf( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', '_s' ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
+			<p><?php printf( wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', '_s' ), array( 'a' => 'href' ) ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
 
 		<?php elseif ( is_search() ) : ?>
 

--- a/search.php
+++ b/search.php
@@ -13,7 +13,7 @@ get_header(); ?>
 		<?php if ( have_posts() ) : ?>
 
 			<header class="page-header">
-				<h1 class="page-title"><?php printf( __( 'Search Results for: %s', '_s' ), '<span>' . get_search_query() . '</span>' ); ?></h1>
+				<h1 class="page-title"><?php printf( wp_kses( __( 'Search Results for: %s', '_s' ), array( 'span' ) ), '<span>' . get_search_query() . '</span>' ); ?></h1>
 			</header><!-- .page-header -->
 
 			<?php /* Start the Loop */ ?>


### PR DESCRIPTION
See #231. For strings that have HTML in them, use `wp_kses()` to make sure only authorized HTML makes it through.
