### PR TITLE
Enqueue customizer script later at wp_enqueue_scripts action

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -18,9 +18,16 @@ function _s_customize_register( $wp_customize ) {
 add_action( 'customize_register', '_s_customize_register' );
 
 /**
- * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
+ * Add the action to enqueue the customizer script at the proper time
  */
 function _s_customize_preview_js() {
-	wp_enqueue_script( '_s_customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), '20130508', true );
+	add_action( 'wp_enqueue_scripts', '_s_enqueue_customize_preview_js' );
 }
 add_action( 'customize_preview_init', '_s_customize_preview_js' );
+
+/**
+ * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
+ */
+function _s_enqueue_customize_preview_js() {
+	wp_enqueue_script( '_s_customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), '20130508', true );
+}


### PR DESCRIPTION
Enqueueing the script at customize_preview_init is too early.
Per http://codex.wordpress.org/Function_Reference/wp_enqueue_script#Notes

> The function should be called using the wp_enqueue_scripts action
> hook if you want to call it on the front-end of the site, like in
> the examples above. To call it on the administration screens, use
> the admin_enqueue_scripts action hook. For the login screen, use the
> login_enqueue_scripts action hook. Calling it outside of an action
> hook can lead to problems, see the ticket #11526 for details.
