### PR TITLE
Change file paths in README to be more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ My ultra-minimal CSS might make me look like theme tartare but that means less s
 * Some small tweaks in `inc/extras.php` that can improve your theming experience.
 * Keyboard navigation for image attachment templates. The script can be found in `js/keyboard-navigation.js`. It’s enqueued in `functions.php`.
 * A script at `js/small-menu.js` that makes your menu a toggled dropdown on small screens (like your phone), ready for CSS artistry. It’s enqueued in `functions.php`.
-* 5 sample CSS layouts in `layouts/`: Two sidebars on the left, two sidebars on the right, a sidebar on either side of your content, and two-column layouts with sidebars on either side.
+* 5 sample CSS layouts in `layouts`: Two sidebars on the left, two sidebars on the right, a sidebar on either side of your content, and two-column layouts with sidebars on either side.
 * Smartly organized starter CSS in `style.css` that will help you to quickly get your design off the ground.
-* The GPL license in `license.txt`. :) Use it to make something cool.
+* Licensed using GPLv2. :) Use it to make something cool.
 
 Getting Started
 ---------------


### PR DESCRIPTION
They now all display using a consistent syntax, and are wrapped in code tags. I also added a missing file extension to the template-tags reference.

This is in an effort to make the README more consistent with the current appearance of http://underscores.me and my proposed changes to it. (See: Automattic/underscores.me#7.)
