### PR TITLE
Add the <main> element to the list of HTML5 selectors

### DIFF
--- a/style.css
+++ b/style.css
@@ -60,6 +60,7 @@ figcaption,
 figure,
 footer,
 header,
+main,
 nav,
 section {
 	display: block;


### PR DESCRIPTION
The `<main>` elements was added in 810e499 but the element was not added to the list in style.css
