### PR TITLE
Add `url` to the list of input selectors

### DIFF
--- a/style.css
+++ b/style.css
@@ -282,6 +282,7 @@ input::-moz-focus-inner { /* Corrects inner padding and border displayed oddly i
 }
 input[type="text"],
 input[type="email"],
+input[type="url"],
 input[type="password"],
 input[type="search"],
 textarea {
@@ -291,6 +292,7 @@ textarea {
 }
 input[type="text"]:focus,
 input[type="email"]:focus,
+input[type="url"]:focus,
 input[type="password"]:focus,
 input[type="search"]:focus,
 textarea:focus {
@@ -298,6 +300,7 @@ textarea:focus {
 }
 input[type="text"],
 input[type="email"],
+input[type="url"],
 input[type="password"],
 input[type="search"] {
 	padding: 3px;


### PR DESCRIPTION
The new core markup for the comment form uses the `url` input type but there's no styling for it in _s yet.
