### PR TITLE
Remove Extra space in theme description

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ Tags:
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
- _s is based on Underscores http://underscores.me/, (C) 2012-2013 Automattic, Inc.
+_s is based on Underscores http://underscores.me/, (C) 2012-2013 Automattic, Inc.
 
 Resetting and rebuilding styles have been helped along thanks to the fine work of
 Eric Meyer http://meyerweb.com/eric/tools/css/reset/index.html


### PR DESCRIPTION
There is an extra space before the theme name in style description area at the top of style.css
