### PR TITLE
The pre tag overflows the area

### DIFF
--- a/style.css
+++ b/style.css
@@ -167,6 +167,9 @@ pre {
 	padding: 1.6em;
 	overflow: auto;
 	max-width: 100%;
+	white-space: pre-wrap; 
+	word-break: break-all;
+	word-wrap: break-word; 
 }
 code, kbd, tt, var {
 	font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;


### PR DESCRIPTION
The pre tag overflows the area. Example http://i.imgur.com/XWuerbP.png and this was the test with http://codex.wordpress.org/Theme_Unit_Test
