### PR TITLE
Destroy62.5

### DIFF
--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@ table, caption, tbody, tfoot, thead, tr, th, td {
 	vertical-align: baseline;
 }
 html {
-	font-size: 62.5%; /* Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
+	font-size: 93.75%; /* 15px / 16px -- Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
 	overflow-y: scroll; /* Keeps page centred in all browsers regardless of content height */
 	-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
 	-ms-text-size-adjust: 100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
@@ -106,7 +106,7 @@ textarea {
 	color: #404040;
 	font-family: sans-serif;
 	font-size: 16px;
-	font-size: 1.6rem;
+	font-size: 1.06666666666667rem; /* 16px / 15px */
 	line-height: 1.5;
 }
 
@@ -161,7 +161,7 @@ pre {
 	background: #eee;
 	font-family: "Courier 10 Pitch", Courier, monospace;
 	font-size: 15px;
-	font-size: 1.5rem;
+	font-size: 1rem;
 	line-height: 1.6;
 	margin-bottom: 1.6em;
 	padding: 1.6em;
@@ -239,7 +239,7 @@ input[type="submit"] {
 	cursor: pointer; /* Improves usability and consistency of cursor style between image-type 'input' and others */
 	-webkit-appearance: button; /* Corrects inability to style clickable 'input' types in iOS */
 	font-size: 12px;
-	font-size: 1.2rem;
+	font-size: 0.8rem; /* 12px / 15px */
 	line-height: 1;
 	padding: .6em 1em .4em;
 	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
@@ -359,6 +359,7 @@ a:active {
 	color: #21759b;
 	display: block;
 	font-size: 14px;
+	font-size: 0.93333333333333rem; /* 14px / 15px */
 	font-weight: bold;
 	height: auto;
 	left: 5px;


### PR DESCRIPTION
Setting the default font size to the percentage equivalent of 10px just to make the math easier is lazy web development.  Set the default font size to what you _really_ want it to be, and use a calculator to figure out the rest.

For more of my thoughts on this, I refer you to http://www.taupecat.com/2013/07/the-62-5-solution/
