### PR TITLE
Simplify Clearing

### DIFF
--- a/style.css
+++ b/style.css
@@ -371,20 +371,17 @@ a:active {
 }
 
 /* Clearing */
-.clear:before,
 .clear:after,
-[class*="content"]:before,
-[class*="content"]:after,
-[class*="site"]:before,
-[class*="site"]:after {
-	content: '';
-	display: table;
+#content:after,
+.clear:before,
+#content:before {
+    content: ' '; 
+    display: table;
 }
 
 .clear:after,
-[class*="content"]:after,
-[class*="site"]:after {
-	clear: both;
+#content:after {
+    clear: both;
 }
 
 


### PR DESCRIPTION
(Second opinion needed)

This should simplify clearing and make the development faster. 

Current clearing causes the issues with floats and display properties in header and footer area with default layout and even more if extended.

The *site which is being cleared 5 times in the header.

.site-header
.site-branding
.site-title
.site-description
.site-content

And one more time for the *content ID.
# content

:before and :after already exist and will produce the same results from the "inner" area and that is #content.

.clear remains just in case if needed.

Tested on several sites for my clients and haven't found any issues. Browser support IE8+ just like the original one.
