### PR TITLE
Added the *zoom: 1; rule to apply the Nicolas Gallagher micro-clearfix

### DIFF
--- a/style.css
+++ b/style.css
@@ -396,6 +396,19 @@ a:active {
 	clear: both;
 }
 
+/**
+ * For IE 6/7 only
+ * Include this rule to trigger hasLayout and contain floats.
+ */
+.clear,
+.entry-content,
+.comment-content,
+.site-header,
+.site-content,
+.site-footer {
+	*zoom: 1;
+}
+
 
 /* =Menu
 ----------------------------------------------- */


### PR DESCRIPTION
Neither IE 6 nor 7 support `display: table;` nor pseudo-elements, so the clearfix solution currently in style.css won't work for those browsers.  The fix, in [Nicolas Gallagher's micro clearfix post](http://nicolasgallagher.com/micro-clearfix-hack/), is to apply `*zoom: 1;` that will trigger hasLayout on those browsers.

Since WordPress' stated browser support continues to be IE7+ (this has been reiterated to me by Nacin during the 3.7/3.8 cycle), the stylesheet for _s should support those browsers out of the box as well.
