### PR TITLE
Fixes #325: bug where Appearance > Header hangs on Step 3 due to wpColorPicker error

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -27,7 +27,7 @@
 function _s_custom_header_setup() {
 	add_theme_support( 'custom-header', apply_filters( '_s_custom_header_args', array(
 		'default-image'          => '',
-		'default-text-color'     => '000',
+		'default-text-color'     => '000000',
 		'width'                  => 1000,
 		'height'                 => 250,
 		'flex-height'            => true,


### PR DESCRIPTION
Wordpress custom-header functionality seems to require default-text-color to be a six-digit hex code. using less than six digits here causes Appearance > Header to hang on step 3
