### PR TITLE
WP Menus > Optional CSS Classes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -44,14 +44,6 @@ function _s_setup() {
 	/**
 	 * This theme uses wp_nav_menu() in one location.
 	 */
-	register_nav_menus( array(
-		'primary' => __( 'Primary Menu', '_s' ),
-	) );
-	
-	/**
-	 *  register_nav_menu used by _s won't show "CSS Classes (Optional)" inserted from Dashboard > Appreance > Menu
-	 * the following would solve the problem
-	 */
 	
 	register_nav_menu( 'primary', __( 'Primary Navigation Menu', '_s' ) );
 


### PR DESCRIPTION
With (array) register_nav_menus() the Optional CSS Classes won't work in Menus

register_nav_menu() should fix it 
