### PR TITLE
Improve Post Format Archive Headings.

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -47,6 +47,9 @@ get_header(); ?>
 						elseif ( is_tax( 'post_format', 'post-format-aside' ) ) :
 							_e( 'Asides', '_s' );
 
+						elseif ( is_tax( 'post_format', 'post-format-gallery' ) ) :
+							_e( 'Galleries', '_s');
+
 						elseif ( is_tax( 'post_format', 'post-format-image' ) ) :
 							_e( 'Images', '_s');
 
@@ -58,6 +61,15 @@ get_header(); ?>
 
 						elseif ( is_tax( 'post_format', 'post-format-link' ) ) :
 							_e( 'Links', '_s' );
+
+						elseif ( is_tax( 'post_format', 'post-format-status' ) ) :
+							_e( 'Statuses', '_s' );
+
+						elseif ( is_tax( 'post_format', 'post-format-audio' ) ) :
+							_e( 'Audios', '_s' );
+
+						elseif ( is_tax( 'post_format', 'post-format-chat' ) ) :
+							_e( 'Chats', '_s' );
 
 						else :
 							_e( 'Archives', '_s' );


### PR DESCRIPTION
Follows up on #95 and https://github.com/Automattic/_s/commit/e3b4907946696c324877b775bdfea8314af1799a#diff-ff638db82c6ac72a05781ba3e086fdf0L48.

The comment made on the original commit is as follows:

> It's worth noting that post formats not accounted for (i.e. not added into wp-admin) should maybe also be added into this template file. What I mean is that if you are using a post with format status and then switch to an _s-based theme, the post will still have the post format status and you will still be able to view it by going to /type/status. Maybe we should take all post formats into account even if support for them isn't explicitly added into functions.php.
