### PR TITLE
sanitize_html_class for $nav_id

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -30,7 +30,7 @@ function _s_content_nav( $nav_id ) {
 	$nav_class = ( is_single() ) ? 'post-navigation' : 'paging-navigation';
 
 	?>
-	<nav role="navigation" id="<?php echo esc_attr( $nav_id ); ?>" class="<?php echo $nav_class; ?>">
+	<nav role="navigation" id="<?php echo sanitize_html_class( $nav_id ); ?>" class="<?php echo $nav_class; ?>">
 		<h1 class="screen-reader-text"><?php _e( 'Post navigation', '_s' ); ?></h1>
 
 	<?php if ( is_single() ) : // navigation links for single posts ?>
@@ -50,7 +50,7 @@ function _s_content_nav( $nav_id ) {
 
 	<?php endif; ?>
 
-	</nav><!-- #<?php echo esc_html( $nav_id ); ?> -->
+	</nav><!-- #<?php echo sanitize_html_class( $nav_id ); ?> -->
 	<?php
 }
 endif; // _s_content_nav


### PR DESCRIPTION
sanitize_html_class is better than esc_attr, since sanitize_html_class strips the string down to A-Z,a-z,0-9,_,-, string allowed for id/class attributes.
http://codex.wordpress.org/Function_Reference/sanitize_html_class
