### PR TITLE
Removed bullet that referenced keyboard-image-navigation.js, since that ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ My ultra-minimal CSS might make me look like theme tartare but that means less s
 * A sample custom header implementation in `inc/custom-header.php` that can be activated by uncommenting one line in functions.php and adding the code snippet found the comments of `inc/custom-header.php` to your `header.php` template.
 * Custom template tags in `inc/template-tags.php` that keep your templates clean and neat and prevent code duplication.
 * Some small tweaks in `inc/extras.php` that can improve your theming experience.
-* Keyboard navigation for image attachment templates. The script can be found in `js/keyboard-image-navigation.js`. It's enqueued in `functions.php`.
 * A script at `js/navigation.js` that makes your menu a toggled dropdown on small screens (like your phone), ready for CSS artistry. It's enqueued in `functions.php`.
 * 2 sample CSS layouts in `layouts` for a sidebar on either side of your content.
 * Smartly organized starter CSS in `style.css` that will help you to quickly get your design off the ground.


### PR DESCRIPTION
...file was deleted.

Only happened to notice this as I was applying the commits that removed all the separate "image" template stuff to an active _s-based project, and saw this line come back in a grep.
