### PR TITLE
removing unneeded css declaration and adding notes

### DIFF
--- a/style.css
+++ b/style.css
@@ -53,9 +53,9 @@ html {
 *,
 *:before,
 *:after { /* apply a natural box layout model to all elements; see http://www.paulirish.com/2012/box-sizing-border-box-ftw/ */
-	-moz-box-sizing: border-box; /* Still needed for Firefox 28; see see http://caniuse.com/#search=box-sizing */
 	-webkit-box-sizing: border-box; /* Not needed for modern webkit but still used by Blackberry Browser 7.0; see http://caniuse.com/#search=box-sizing */
-	box-sizing: border-box;
+	-moz-box-sizing: 	border-box; /* Still needed for Firefox 28; see http://caniuse.com/#search=box-sizing */
+	box-sizing: 		border-box;
 }
 body {
 	background: #fff;


### PR DESCRIPTION
Note that Firefox 28 does not use !important in the UA stylesheet
anymore for that declaration, and FF3/4 (and up to FF9) has less than 1% browser share
according to http://en.wikipedia.org/wiki/Template:Firefox_usage_share
