### PR TITLE
Use em instead of px for menu media query

### DIFF
--- a/style.css
+++ b/style.css
@@ -458,7 +458,7 @@ a:active {
 	display: none;
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 37.5em) {
 	.menu-toggle,
 	.main-navigation.toggled .nav-menu {
 		display: block;


### PR DESCRIPTION
Using `em` instead of `px` preserves proportions across a wider range of browsers and devices for the responsive nav menu when users zoom. See http://blog.cloudfour.com/the-ems-have-it-proportional-media-queries-ftw/
