### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 Thank-you for taking the time to contribute to _s. Here are a few guidelines to keep in mind when submitting issues and pull requests:
 
 - _s only supports Internet Exporter versions 9 and greater. Please don't open issues that deal with lesser versions of Internet Exporter.
+- _s supports the last two major versions of all other browsers, as well as the two most recent major versions of WordPress
 - Having multiple `<h1>` tags in a page is valid by the HTML5 spec, and this is something that we will not be changing.
 - The preferred method of generating a new theme based on _s is the [Underscores.me](http://underscores.me) website. If you have an alternative method, such as a shell script, feel free to write a blog post about it or host it in a separate repo.
 - If your issue is specific to the [Underscores.me](http://underscores.me) website, please open a pull request on the [Underscores.me GitHub repository](https://github.com/Automattic/underscores.me) instead of here.


### PR DESCRIPTION
Quite a few people are opening issues which have been resolved before, such as using multiple `<h1>` tags per page, and adding support for old versions of IE.

I suggest we add a [contributing guidelines file](https://github.com/blog/1184-contributing-guidelines) to this repositiory, and include a list of common issues that people might be tempted to bring up again.

When people go to open an issue or pull request, they will see this notice:

![](https://github-images.s3.amazonaws.com/skitch/issues-20120913-162539.jpg)

…which will link to the `CONTRIBUTING.md` file in the root of this repo.
