### PR TITLE
Custom Header file is implemented

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -94,7 +94,7 @@ add_action( 'wp_enqueue_scripts', '_s_scripts' );
 /**
  * Implement the Custom Header feature.
  */
-//require get_template_directory() . '/inc/custom-header.php';
+require get_template_directory() . '/inc/custom-header.php';
 
 /**
  * Custom template tags for this theme.


### PR DESCRIPTION
The custom-header file was implemented, and should be activated by default for new themes.
Not having the custom-header activated, though having the file in the 'inc' directory creates confusion for new theme makers, as they see the file is there but may think it's broken due to it not doing appearing in the theme options.
