### PR TITLE
Move the archive title into a function

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -16,57 +16,7 @@ get_header(); ?>
 
 			<header class="page-header">
 				<h1 class="page-title">
-					<?php
-						if ( is_category() ) :
-							single_cat_title();
-
-						elseif ( is_tag() ) :
-							single_tag_title();
-
-						elseif ( is_author() ) :
-							printf( __( 'Author: %s', '_s' ), '<span class="vcard">' . get_the_author() . '</span>' );
-
-						elseif ( is_day() ) :
-							printf( __( 'Day: %s', '_s' ), '<span>' . get_the_date() . '</span>' );
-
-						elseif ( is_month() ) :
-							printf( __( 'Month: %s', '_s' ), '<span>' . get_the_date( _x( 'F Y', 'monthly archives date format', '_s' ) ) . '</span>' );
-
-						elseif ( is_year() ) :
-							printf( __( 'Year: %s', '_s' ), '<span>' . get_the_date( _x( 'Y', 'yearly archives date format', '_s' ) ) . '</span>' );
-
-						elseif ( is_tax( 'post_format', 'post-format-aside' ) ) :
-							_e( 'Asides', '_s' );
-
-						elseif ( is_tax( 'post_format', 'post-format-gallery' ) ) :
-							_e( 'Galleries', '_s');
-
-						elseif ( is_tax( 'post_format', 'post-format-image' ) ) :
-							_e( 'Images', '_s');
-
-						elseif ( is_tax( 'post_format', 'post-format-video' ) ) :
-							_e( 'Videos', '_s' );
-
-						elseif ( is_tax( 'post_format', 'post-format-quote' ) ) :
-							_e( 'Quotes', '_s' );
-
-						elseif ( is_tax( 'post_format', 'post-format-link' ) ) :
-							_e( 'Links', '_s' );
-
-						elseif ( is_tax( 'post_format', 'post-format-status' ) ) :
-							_e( 'Statuses', '_s' );
-
-						elseif ( is_tax( 'post_format', 'post-format-audio' ) ) :
-							_e( 'Audios', '_s' );
-
-						elseif ( is_tax( 'post_format', 'post-format-chat' ) ) :
-							_e( 'Chats', '_s' );
-
-						else :
-							_e( 'Archives', '_s' );
-
-						endif;
-					?>
+					<?php _s_archive_title(); ?>
 				</h1>
 				<?php
 					// Show an optional term description.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -95,6 +95,63 @@ function _s_posted_on() {
 }
 endif;
 
+if ( ! function_exists( '_s_archive_title' ) ) {
+/**
+ * Prints archive title according to the current archive
+ */
+function _s_archive_title() {
+	if ( is_category() ) {
+		single_cat_title();
+
+	} elseif ( is_tag() ) {
+		single_tag_title();
+
+	} elseif ( is_author() ) {
+		printf( __( 'Author: %s', '_s' ), '<span class="vcard">' . get_the_author() . '</span>' );
+
+	} elseif ( is_day() ) {
+		printf( __( 'Day: %s', '_s' ), '<span>' . get_the_date() . '</span>' );
+
+	} elseif ( is_month() ) {
+		printf( __( 'Month: %s', '_s' ), '<span>' . get_the_date( _x( 'F Y', 'monthly archives date format', '_s' ) ) . '</span>' );
+
+	} elseif ( is_year() ) {
+		printf( __( 'Year: %s', '_s' ), '<span>' . get_the_date( _x( 'Y', 'yearly archives date format', '_s' ) ) . '</span>' );
+
+	} elseif ( is_tax( 'post_format', 'post-format-aside' ) ) {
+		_e( 'Asides', '_s' );
+
+	} elseif ( is_tax( 'post_format', 'post-format-gallery' ) ) {
+		_e( 'Galleries', '_s');
+
+	} elseif ( is_tax( 'post_format', 'post-format-image' ) ) {
+		_e( 'Images', '_s');
+
+	} elseif ( is_tax( 'post_format', 'post-format-video' ) ) {
+		_e( 'Videos', '_s' );
+
+	} elseif ( is_tax( 'post_format', 'post-format-quote' ) ) {
+		_e( 'Quotes', '_s' );
+
+	} elseif ( is_tax( 'post_format', 'post-format-link' ) ) {
+		_e( 'Links', '_s' );
+
+	} elseif ( is_tax( 'post_format', 'post-format-status' ) ) {
+		_e( 'Statuses', '_s' );
+
+	} elseif ( is_tax( 'post_format', 'post-format-audio' ) ) {
+		_e( 'Audios', '_s' );
+
+	} elseif ( is_tax( 'post_format', 'post-format-chat' ) ) {
+		_e( 'Chats', '_s' );
+
+	} else {
+		_e( 'Archives', '_s' );
+
+	}
+}
+}
+
 /**
  * Returns true if a blog has more than 1 category.
  */


### PR DESCRIPTION
Move the code for the archive title into a function. The reason for the this is that the archive title is a lot of PHP and this cleans up the html side of things. It also allows the archive title to be moved and displayed elsewhere easily.
