### PR TITLE
Add generic taxonomy term to archive.php

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -61,6 +61,10 @@ get_header(); ?>
 
 						elseif ( is_tax( 'post_format', 'post-format-chat' ) ) :
 							_e( 'Chats', '_s' );
+							
+						elseif (is_tax() ) : 
+							$single_tax_term = get_queried_object(); 
+							echo $single_tax_term->name;
 
 						else :
 							_e( 'Archives', '_s' );


### PR DESCRIPTION
_archive.php_ currently doesn't handle custom taxonomies well. This pulls the term name in as the archive title. I've added it after the post-formats so they still work.
