### PR TITLE
Add media queries to sample layout CSS

### DIFF
--- a/layouts/content-sidebar.css
+++ b/layouts/content-sidebar.css
@@ -3,20 +3,22 @@ Theme Name: _s
 Layout: Content-Sidebar
 */
 
-.content-area {
-	float: left;
-	margin: 0 -25% 0 0;
-	width: 100%;
-}
-.site-main {
-	margin: 0 25% 0 0;
-}
-.site-content .widget-area {
-	float: right;
-	overflow: hidden;
-	width: 25%;
-}
-.site-footer {
-	clear: both;
-	width: 100%;
+@media screen and (min-width: 600px) {
+	.content-area {
+		float: left;
+		margin: 0 -25% 0 0;
+		width: 100%;
+	}
+	.site-main {
+		margin: 0 25% 0 0;
+	}
+	.site-content .widget-area {
+		float: right;
+		overflow: hidden;
+		width: 25%;
+	}
+	.site-footer {
+		clear: both;
+		width: 100%;
+	}
 }

--- a/layouts/sidebar-content.css
+++ b/layouts/sidebar-content.css
@@ -3,20 +3,22 @@ Theme Name: _s
 Layout: Sidebar-Content
 */
 
-.content-area {
-	float: right;
-	margin: 0 0 0 -25%;
-	width: 100%;
-}
-.site-main {
-	margin: 0 0 0 25%;
-}
-.site-content .widget-area {
-	float: left;
-	overflow: hidden;
-	width: 25%;
-}
-.site-footer {
-	clear: both;
-	width: 100%;
+@media screen and (min-width: 600px) {
+	.content-area {
+		float: right;
+		margin: 0 0 0 -25%;
+		width: 100%;
+	}
+	.site-main {
+		margin: 0 0 0 25%;
+	}
+	.site-content .widget-area {
+		float: left;
+		overflow: hidden;
+		width: 25%;
+	}
+	.site-footer {
+		clear: both;
+		width: 100%;
+	}
 }


### PR DESCRIPTION
The sample layouts only do half of the job. The menu toggle media query
in style.css implies that _s is responsive ready. Adding sample layout
min-width media queries to match the menu media query keeps things
unified and provides completed sample layout CSS.
