### PR TITLE
Less HTML for translators

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -78,7 +78,7 @@ function _s_comment( $comment, $args, $depth ) {
 			<footer class="comment-meta">
 				<div class="comment-author vcard">
 					<?php if ( 0 != $args['avatar_size'] ) echo get_avatar( $comment, $args['avatar_size'] ); ?>
-					<?php printf( '%s <span class="says">' . __( 'says:', '_s' ) . '</span>', sprintf( '<cite class="fn">%s</cite>', get_comment_author_link() ) ); ?>
+					<?php printf( __( '%s <span class="says">says:</span>', '_s' ), sprintf( '<cite class="fn">%s</cite>', get_comment_author_link() ) ); ?>
 				</div><!-- .comment-author -->
 
 				<div class="comment-metadata">
@@ -182,7 +182,7 @@ function _s_posted_on() {
 		esc_html( get_the_modified_date() )
 	);
 
-	printf( '<span class="posted-on">' . _x( 'Posted on', 'publication date', '_s' ) . ' %1$s</span><span class="byline"> ' . _x( 'by', 'posted by who', '_s' ) . ' %2$s</span>',
+	printf( __( '<span class="posted-on">Posted on %1$s</span><span class="byline"> by %2$s</span>', '_s' ),
 		sprintf( '<a href="%1$s" rel="bookmark">%2$s</a>',
 			esc_url( get_permalink() ),
 			$time_string


### PR DESCRIPTION
In my opinion there is a lot of HTML code which a translator shouldn't have to translate.
