### PR TITLE
Copyright date update

### DIFF
--- a/languages/_s.pot
+++ b/languages/_s.pot
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 Automattic
+# Copyright (C) 2012-2014 Automattic, Inc.
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""


### PR DESCRIPTION
Copyright date update and consistency reasons added 2012 and Inc after the Automattic. As in: https://github.com/Automattic/_s/blob/master/style.css
