### PR TITLE
Space before _s in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ Tags:
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
- _s is based on Underscores http://underscores.me/, (C) 2012-2014 Automattic, Inc.
+_s is based on Underscores http://underscores.me/, (C) 2012-2014 Automattic, Inc.
 
 Resetting and rebuilding styles have been helped along thanks to the fine work of
 Eric Meyer http://meyerweb.com/eric/tools/css/reset/index.html


### PR DESCRIPTION
This is very small update for `_s`. It's not a big deal, but it looks weird once the Theme is generated and  `_s` replaced with new name from http://underscores.me/

Thanks :)
