### PR TITLE
Fix overlapping custom header preview

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -87,6 +87,9 @@ function _s_admin_header_style() {
 ?>
 	<style type="text/css">
 		.appearance_page_custom-header #headimg {
+			-webkit-box-sizing: border-box;
+			-moz-box-sizing:    border-box;
+			box-sizing:         border-box;
 			border: none;
 		}
 		#headimg h1,


### PR DESCRIPTION
When we need to setup a different background for the preview, we better give it a padding. But it breaks and overlapping the container. Adding 'box-sizing' fixed it.
![overlapping custom header preview](https://f.cloud.github.com/assets/914534/2472052/660245dc-b030-11e3-845e-ec2e67a71924.png)
