### PR TITLE
Add support for html5 caption

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -60,6 +60,7 @@ function _s_setup() {
 		'search-form',
 		'comment-form',
 		'gallery',
+		'caption',
 	) );
 }
 endif; // _s_setup


### PR DESCRIPTION
HTML5 support for image captions is in 3.9 now (https://core.trac.wordpress.org/changeset/27668). Leaving out any changes to the CSS for now so previous WordPress versions are still supported.
