### PR TITLE
Remove html from "Posted on" string

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -82,17 +82,18 @@ function _s_posted_on() {
 		esc_html( get_the_modified_date() )
 	);
 
-	printf(
-		'<span class="posted-on">' . __( 'Posted on %1$s', '_s' ) . '</span><span class="byline"> ' . __( 'by %2$s', '_s' ) . '</span>',
-		sprintf( '<a href="%1$s" rel="bookmark">%2$s</a>',
-			esc_url( get_permalink() ),
-			$time_string
-		),
-		sprintf( '<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
-			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
-			esc_html( get_the_author() )
-		)
+	$posted_on = sprintf(
+		_x( 'Posted on %s', 'post date', '_s' ),
+		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
 	);
+
+	$byline = sprintf(
+		_x( 'by %s', 'post author', '_s' ),
+		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+	);
+
+	echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>';
+
 }
 endif;
 


### PR DESCRIPTION
This reduces the amount of HTML in the string. It should be no problem splitting the two strings as they both can be used on their own and still make sense.

@translators: My suggestion here is to change the string from:
`<span class="posted-on">Posted on %1$s</span><span class="byline"> by %2$s</span>`
to:
`Posted on %1$s` and `by %2$s`

Please let me know in the comments if it would work or not in your language.
