### PR TITLE
Added 'on' prefix for hashchange event name in IE

### DIFF
--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -4,8 +4,9 @@
 	    is_ie     = navigator.userAgent.toLowerCase().indexOf( 'msie' )   > -1;
 
 	if ( ( is_webkit || is_opera || is_ie ) && 'undefined' !== typeof( document.getElementById ) ) {
-		var eventMethod = ( window.addEventListener ) ? 'addEventListener' : 'attachEvent';
-		window[ eventMethod ]( 'hashchange', function() {
+		var eventMethod = ( window.addEventListener ) ? 'addEventListener' : 'attachEvent',
+		    eventPrefix = ( window.addEventListener ) ? '' : 'on';
+		window[ eventMethod ]( eventPrefix + 'hashchange', function() {
 			var element = document.getElementById( location.hash.substring( 1 ) );
 
 			if ( element ) {


### PR DESCRIPTION
For `attachEvent`, the event name needs an `'on'` prefix; see http://msdn.microsoft.com/en-us/library/ie/cc288209%28v=vs.85%29.aspx
