### PR TITLE
RDFa 1.1 schema

### DIFF
--- a/header.php
+++ b/header.php
@@ -7,11 +7,11 @@
  * @package _s
  */
 ?><!DOCTYPE html>
-<html <?php language_attributes(); ?>>
+<html <?php language_attributes(); ?> typeof="schema:Blog">
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title><?php wp_title( '|', true, 'right' ); ?></title>
+<title property="schema:about"><?php wp_title( '|', true, 'right' ); ?></title>
 <link rel="profile" href="http://gmpg.org/xfn/11">
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 
@@ -23,8 +23,8 @@
 
 	<header id="masthead" class="site-header" role="banner">
 		<div class="site-branding">
-			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-			<h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
+			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" property="schema:url" rel="home"><span property="schema:name"><?php bloginfo( 'name' ); ?></span></a></h1>
+			<h2 class="site-description" property="schema:description"><?php bloginfo( 'description' ); ?></h2>
 		</div>
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">


### PR DESCRIPTION
Starting to use this RDFa 1.1 lite with schema.org/Blog and all the way down.

Symantic Web:
http://www.w3.org/TR/rdfa-core/
http://www.w3.org/2011/rdfa-context/rdfa-1.1
See also:
http://manu.sporny.org/2012/mythical-differences/

At this time it isn't necessary using vocab="http://www.w3.org/2011/rdfa-context/rdfa-1.1" anymore. So you can test it at http://validator.w3.org/nu/
