### PR TITLE
Removed addEvent support

### DIFF
--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -3,9 +3,8 @@
 	    is_opera  = navigator.userAgent.toLowerCase().indexOf( 'opera' )  > -1,
 	    is_ie     = navigator.userAgent.toLowerCase().indexOf( 'msie' )   > -1;
 
-	if ( ( is_webkit || is_opera || is_ie ) && 'undefined' !== typeof( document.getElementById ) ) {
-		var eventMethod = ( window.addEventListener ) ? 'addEventListener' : 'attachEvent';
-		window[ eventMethod ]( 'hashchange', function() {
+	if ( ( is_webkit || is_opera || is_ie ) && document.getElementById && window.addEventListener ) {
+		window.addEventListener( 'hashchange', function() {
 			var element = document.getElementById( location.hash.substring( 1 ) );
 
 			if ( element ) {


### PR DESCRIPTION
As noted in #456, IE8 is no longer supported.

Also, undefined is falsey in JavaScript, so the typeof check was unnecessary.
