### PR TITLE
add HTML5 caption support with WordPress 3.9

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -60,6 +60,7 @@ function _s_setup() {
 		'search-form',
 		'comment-form',
 		'gallery',
+		'caption'
 	) );
 }
 endif; // _s_setup


### PR DESCRIPTION
Since WordPress 3.9 is final and live, add new HTML5 caption support
