### PR TITLE
Make "Skip to content" first focusable element 

### DIFF
--- a/style.css
+++ b/style.css
@@ -451,9 +451,6 @@ a:active {
 .screen-reader-text {
 	clip: rect(1px, 1px, 1px, 1px);
 	position: absolute !important;
-	height: 1px;
-	width: 1px; 
-	overflow: hidden;
 }
 
 .screen-reader-text:hover,


### PR DESCRIPTION
WordPress accessibility guidelines (required for the accessibility-ready tag) state that the skip to content link must "Be the first focusable element perceived by a user via screen reader or keyboard navigation."

In the current iteration the skip to content link appears as the second or third element depending on whether the mobile navigation button is visible or not. This patch moves the link to become the first element of the #page container and thus the first focusable element. 

http://make.wordpress.org/themes/guidelines/guidelines-accessibility/
