### PR TITLE
Fix Skip to content link

### DIFF
--- a/header.php
+++ b/header.php
@@ -20,6 +20,7 @@
 
 <body <?php body_class(); ?>>
 <div id="page" class="hfeed site">
+	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', '_s' ); ?></a>
 
 	<header id="masthead" class="site-header" role="banner">
 		<div class="site-branding">
@@ -29,8 +30,6 @@
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">
 			<h1 class="menu-toggle"><?php _e( 'Menu', '_s' ); ?></h1>
-			<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', '_s' ); ?></a>
-
 			<?php wp_nav_menu( array( 'theme_location' => 'primary' ) ); ?>
 		</nav><!-- #site-navigation -->
 	</header><!-- #masthead -->


### PR DESCRIPTION
... the first focusable element perceived via screen reader or keyboard navigation. Ensures _s meets accessibility-ready guidelines as per http://make.wordpress.org/themes/guidelines/guidelines-accessibility/
