### PR TITLE
remove optional 'search' $name parameter

### DIFF
--- a/search.php
+++ b/search.php
@@ -19,14 +19,7 @@ get_header(); ?>
 			<?php /* Start the Loop */ ?>
 			<?php while ( have_posts() ) : the_post(); ?>
 
-				<?php
-				/**
-				 * Run the loop for the search to output the results.
-				 * If you want to overload this in a child theme then include a file
-				 * called content-search.php and that will be used instead.
-				 */
-				get_template_part( 'content', 'search' );
-				?>
+				<?php get_template_part( 'content' ); ?>
 
 			<?php endwhile; ?>
 


### PR DESCRIPTION
No `content-search.php` file exists in `_s` and making a call to that file as a way to suggest creating it is both inefficient and unnecessary. See discussion [here](https://github.com/Automattic/_s/issues/487).
