### PR TITLE
Fixes overflow issue on .screen-reader-text

### DIFF
--- a/style.css
+++ b/style.css
@@ -451,6 +451,9 @@ a:active {
 .screen-reader-text {
 	clip: rect(1px, 1px, 1px, 1px);
 	position: absolute !important;
+	height: 1px;
+	width: 1px; 
+	overflow: hidden;
 }
 
 .screen-reader-text:hover,


### PR DESCRIPTION
The current iteration of the .screen-reader-text rule does not account for a well known issue in which an element with the class applied is positioned hard right on the screen. In those cases the clip feature does not work properly in Webkit and other browsers and the browser forces horizontal scrolling to the right of the content frame. 

A full explanation of the problem and the solution can be found here: http://snook.ca/archives/html_and_css/hiding-content-for-accessibility

The addition of height/width 1px and overflow:hidden is the recommended markup for this type of behavior from several accessibility authorities. It does not cause conflicts with existing code because the hover/active/focus class redefines height and width as auto.
