### PR TITLE
Adjust dropdown menu styles so they work with screen readers

### DIFF
--- a/style.css
+++ b/style.css
@@ -383,9 +383,9 @@ a:active {
 .main-navigation ul ul {
 	box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
 	float: left;
-	left: -999em;
 	position: absolute;
 	top: 1.5em;
+	left: -999em;
 	z-index: 99999;
 }
 .main-navigation ul ul ul {


### PR DESCRIPTION
Currently, screen reader users cannot access the menu links in the main navigation because of a `display: none;` used on the `ul` elements.

This pull request does two major things:
- Changes dropdown menu styles to position them offscreen so screen reader users can still access the links.
- Brings the dropdown menu techniques more in line with how they're done in Twenty Fourteen.
