### PR TITLE
Move skip-to-content link 

### DIFF
--- a/header.php
+++ b/header.php
@@ -20,7 +20,8 @@
 
 <body <?php body_class(); ?>>
 <div id="page" class="hfeed site">
-
+	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', '_s' ); ?></a>
+        
 	<header id="masthead" class="site-header" role="banner">
 		<div class="site-branding">
 			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
@@ -29,8 +30,6 @@
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">
 			<h1 class="menu-toggle"><?php _e( 'Menu', '_s' ); ?></h1>
-			<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', '_s' ); ?></a>
-
 			<?php wp_nav_menu( array( 'theme_location' => 'primary' ) ); ?>
 		</nav><!-- #site-navigation -->
 	</header><!-- #masthead -->


### PR DESCRIPTION
Resubmitting patch as separate element to make it easier to patch. Moves Skip to Content link to the top of the page to make it the first focusable element on the page. This ensures that themes built on _s meet basic requirements for the accessibility-ready tag in the WordPress Theme Directory.
