### PR TITLE
widgettitle value

### DIFF
--- a/404.php
+++ b/404.php
@@ -24,7 +24,7 @@ get_header(); ?>
 
 					<?php if ( _s_categorized_blog() ) : // Only show the widget if site has multiple categories. ?>
 					<div class="widget widget_categories">
-						<h2 class="widgettitle"><?php _e( 'Most Used Categories', '_s' ); ?></h2>
+						<h2 class="widget-title"><?php _e( 'Most Used Categories', '_s' ); ?></h2>
 						<ul>
 						<?php
 							wp_list_categories( array(


### PR DESCRIPTION
`widgettitle` doesn't really have any value here or in core. Proposing to change to `widget-title` instead. 

The class is available only in `../../widgets.php` and not present in any of the stylesheet's, at least I could not locate one. Just like in my previous proposal, this is for the consistency reasons only.
