### PR TITLE
textarea width

### DIFF
--- a/style.css
+++ b/style.css
@@ -337,7 +337,7 @@ textarea {
 	overflow: auto; /* Removes default vertical scrollbar in IE6/7/8/9 */
 	padding-left: 3px;
 	vertical-align: top; /* Improves readability and alignment in all browsers */
-	width: 98%;
+	width: 100%;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
We can safely increase the textarea width from 98% to 100%. 

`box-sizing` handles the layout nicely and it won't allow the overflow. 

If more details is needed, please see: http://davidwalsh.name/textarea-width this is the best example I could find.
