### PR TITLE
_s_posted_on() classes

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -78,7 +78,7 @@ function _s_posted_on() {
 		esc_html( get_the_modified_date() )
 	);
 
-	printf( __( '<span class="posted-on">Posted on %1$s</span><span class="byline"> by %2$s</span>', '_s' ),
+	printf( __( '<span class="posted-on">Posted on</span> <span class="posted-time">%1$s</span> <span class="byline">by</span> %2$s', '_s' ),
 		sprintf( '<a href="%1$s" rel="bookmark">%2$s</a>',
 			esc_url( get_permalink() ),
 			$time_string


### PR DESCRIPTION
If we want to hide Posted on `posted-on` the date will disappear as well. Same goes for Jane Doe `byline` too. 

We don't need to do anything with `%2$s` because `author vcard` is already there.

I am sure that this will have low impact on localization.

Let me know if I am not explaining this properly :)
