### PR TITLE
Input Redundancy

### DIFF
--- a/style.css
+++ b/style.css
@@ -317,6 +317,7 @@ textarea {
 	color: #666;
 	border: 1px solid #ccc;
 	border-radius: 3px;
+	padding: 3px;
 }
 input[type="text"]:focus,
 input[type="email"]:focus,
@@ -326,16 +327,8 @@ input[type="search"]:focus,
 textarea:focus {
 	color: #111;
 }
-input[type="text"],
-input[type="email"],
-input[type="url"],
-input[type="password"],
-input[type="search"] {
-	padding: 3px;
-}
 textarea {
 	overflow: auto; /* Removes default vertical scrollbar in IE6/7/8/9 */
-	padding-left: 3px;
 	vertical-align: top; /* Improves readability and alignment in all browsers */
 	width: 100%;
 }


### PR DESCRIPTION
Proposing to delete the input redundancy. This should not affect the textarea and will eliminate 7 lines of CSS :)
`textarea { padding-left: 3px; }` is no longer needed because we added 100% with while back and `padding: 3px;` will fit in nicely.

What do you think?
