### PR TITLE
Add hidden post title to the continue reading link

### DIFF
--- a/content.php
+++ b/content.php
@@ -16,7 +16,14 @@
 	</header><!-- .entry-header -->
 
 	<div class="entry-content">
-		<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', '_s' ) ); ?>
+		<?php
+			/* translators: %s: Name of current post */
+			the_content( sprintf(
+				__( 'Continue reading %s <span class="meta-nav">&rarr;</span>', '_s' ), 
+				the_title( '<span class="screen-reader-text">"', '"</span>', false )
+			) );
+		?>
+
 		<?php
 			wp_link_pages( array(
 				'before' => '<div class="page-links">' . __( 'Pages:', '_s' ),


### PR DESCRIPTION
Hello, just a suggestion, but in light of the [link text accessibility guidelines](http://make.wordpress.org/themes/guidelines/guidelines-accessibility/) at wordpress.org is it worth adding the post title into 'continue reading' links as hidden screen reader text?
