### PR TITLE
Color values for links from name to hexadecimal

### DIFF
--- a/style.css
+++ b/style.css
@@ -347,15 +347,15 @@ textarea {
 5.1 Links
 --------------------------------------------------------------*/
 a {
-	color: royalblue;
+	color: #4169E1;
 }
 a:visited {
-	color: purple;
+	color: #800080;
 }
 a:hover,
 a:focus,
 a:active {
-	color: midnightblue;
+	color: #191970;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
Changed the link values from color name to hexadecimal. All other color values on this stylesheet are in either hexadecimal or RGBA.
