### PR TITLE
Left Property for Primary Menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -389,7 +389,6 @@ a:active {
 	z-index: 99999;
 }
 .main-navigation ul ul ul {
-	left: -999em;
 	top: 0;
 }
 .main-navigation ul ul a {


### PR DESCRIPTION
Since `.main-navigation ul ul ul {` already inherits all but `top: 1.5em;` from the parent `.main-navigation ul ul ul {` we don't need `left: -999em;`. Basically it has no use at all.

Tested and works as usual without it :)

P.S. Unless there's something that I am not seeing.
