### PR TITLE
Add a non-breaking space to _s_post_nav()

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -52,8 +52,8 @@ function _s_post_nav() {
 		<h1 class="screen-reader-text"><?php _e( 'Post navigation', '_s' ); ?></h1>
 		<div class="nav-links">
 			<?php
-				previous_post_link( '<div class="nav-previous">%link</div>', _x( '<span class="meta-nav">&larr;</span> %title', 'Previous post link', '_s' ) );
-				next_post_link(     '<div class="nav-next">%link</div>',     _x( '%title <span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ) );
+				previous_post_link( '<div class="nav-previous">%link</div>', _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ) );
+				next_post_link(     '<div class="nav-next">%link</div>',     _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ) );
 			?>
 		</div><!-- .nav-links -->
 	</nav><!-- .navigation -->


### PR DESCRIPTION
Sometimes the title length of a previous or next post would cause the arrow (larr/rarr) in the link to be wrapped to the next line. Adding a non-breaking space between the title and the arrow will stick it to the last word in the title.
