### PR TITLE
Adds 'no-sidebar' class when no sidebar widgets are used, to match merge from #529

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -33,7 +33,7 @@ function _s_body_classes( $classes ) {
 
 	// Adds a class of no-sidebar when sidebar-1 has no widgets.
 	if ( ! is_active_sidebar( 'sidebar-1' ) ) {
-		$classes[] = 'no-sidebar';
+		$classes[] = 'no-sidebar-1';
 	}
 
 	return $classes;


### PR DESCRIPTION
Based on discussion with @philiparthurmoore in #529. Decided to name the class 'no-sidebar' instead of 'full-width-site' because _s based themes don't necessarily have to have two-column layouts, even with sidebar populated.
