### PR TITLE
Provide function_exists() checks for _s functions

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -33,7 +33,7 @@ function _s_paging_nav() {
 	</nav><!-- .navigation -->
 	<?php
 }
-endif;
+endif; // _s_paging_nav
 
 if ( ! function_exists( '_s_post_nav' ) ) :
 /**
@@ -59,7 +59,7 @@ function _s_post_nav() {
 	</nav><!-- .navigation -->
 	<?php
 }
-endif;
+endif; // _s_post_nav
 
 if ( ! function_exists( '_s_posted_on' ) ) :
 /**
@@ -91,8 +91,9 @@ function _s_posted_on() {
 	echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>';
 
 }
-endif;
+endif; // _s_posted_on
 
+if ( ! function_exists( '_s_categorized_blog' ) ) :
 /**
  * Returns true if a blog has more than 1 category.
  *
@@ -123,7 +124,9 @@ function _s_categorized_blog() {
 		return false;
 	}
 }
+endif; // _s_categorized_blog
 
+if ( ! function_exists( '_s_category_transient_flusher' ) ) :
 /**
  * Flush out the transients used in _s_categorized_blog.
  */
@@ -131,5 +134,6 @@ function _s_category_transient_flusher() {
 	// Like, beat it. Dig?
 	delete_transient( '_s_categories' );
 }
+endif; // _s_category_transient_flusher
 add_action( 'edit_category', '_s_category_transient_flusher' );
 add_action( 'save_post',     '_s_category_transient_flusher' );


### PR DESCRIPTION
Reading through `template-tags.php` I noticed that some of the _s functions declared had `function_exists()` checks, while some didn’t. I figured it’d be better to be consistent with this.

I went ahead and did this for `template-tags.php`. I also added the name of the function checked after each `endif`. (I found this pattern surrounding the `_s_setup()` declaration in `functions.php` and thought it’d be a good one to follow. I also kept the `add_action()` calls outside of the `function_exists()` checks, as I found with that declaration. Let me know if that should be switched.)

Should the rest of the _s functions be wrapped like this? (All found in `functions.php` and the files in `inc` as far as I can tell.) I can do it if it seems like a good plan.
