### PR TITLE
Add trailing slash to `layouts` in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ My ultra-minimal CSS might make me look like theme tartare but that means less s
 * Custom template tags in `inc/template-tags.php` that keep your templates clean and neat and prevent code duplication.
 * Some small tweaks in `inc/extras.php` that can improve your theming experience.
 * A script at `js/navigation.js` that makes your menu a toggled dropdown on small screens (like your phone), ready for CSS artistry. It's enqueued in `functions.php`.
-* 2 sample CSS layouts in `layouts` for a sidebar on either side of your content.
+* 2 sample CSS layouts in `layouts/` for a sidebar on either side of your content.
 * Smartly organized starter CSS in `style.css` that will help you to quickly get your design off the ground.
 * Licensed under GPLv2 or later. :) Use it to make something cool.
 


### PR DESCRIPTION
This is to bring the readme up to parity with what was suggested in Automattic/underscores.me#24, meaning that files have their extensions and folders have a trailing slash. The only thing that needed to change was the reference to the layouts folder.

P.S. Sorry for all the incremental changes to the readme! It’s kind of nitpicky stuff, I know, but consistency is useful.
