### PR TITLE
Use lowercase `doctype`

### DIFF
--- a/header.php
+++ b/header.php
@@ -6,7 +6,7 @@
  *
  * @package _s
  */
-?><!DOCTYPE html>
+?><!doctype html>
 <html <?php language_attributes(); ?>>
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">


### PR DESCRIPTION
Since it's [case-insensitive](http://www.whatwg.org/specs/web-apps/current-work/multipage/syntax.html#the-doctype), use all lowercase `<!doctype html>` instead of `<!DOCTYPE html>` to be consistent with the other html tags.
