### PR TITLE
Escape bloginfo output

### DIFF
--- a/header.php
+++ b/header.php
@@ -13,7 +13,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?php wp_title( '|', true, 'right' ); ?></title>
 <link rel="profile" href="http://gmpg.org/xfn/11">
-<link rel="pingback" href="<?php echo esc_attr( get_bloginfo( 'pingback_url' ) ); ?>">
+<link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 
 <?php wp_head(); ?>
 </head>


### PR DESCRIPTION
I was using _s for a quick stub for a VIP theme, and I was requested to escape the `bloginfo()` output. Since _s is an encouraged starting point for VIP themes, it seems this escaping should be made in _s as well.
