### PR TITLE
Mobile-first toggle menu

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -61,19 +61,24 @@
 }
 
 /* Small menu */
-.menu-toggle {
+.menu-toggle,
+.main-navigation.toggled .nav-menu {
+	display: block;
+}
+
+.main-navigation ul {
 	display: none;
 }
 
-@media screen and (max-width: 600px) {
-	.menu-toggle,
-	.main-navigation.toggled .nav-menu {
-		display: block;
-	}
+@media screen and (min-width: 601px) {
 
-	.main-navigation ul {
+	.menu-toggle {
 		display: none;
 	}
+	.main-navigation ul {
+		display: block;
+	}
+	
 }
 
 .site-main .comment-navigation,

--- a/style.css
+++ b/style.css
@@ -497,19 +497,24 @@ a:active {
 }
 
 /* Small menu */
-.menu-toggle {
+.menu-toggle,
+.main-navigation.toggled .nav-menu {
+	display: block;
+}
+
+.main-navigation ul {
 	display: none;
 }
 
-@media screen and (max-width: 600px) {
-	.menu-toggle,
-	.main-navigation.toggled .nav-menu {
-		display: block;
-	}
+@media screen and (min-width: 601px) {
 
-	.main-navigation ul {
+	.menu-toggle {
 		display: none;
 	}
+	.main-navigation ul {
+		display: block;
+	}
+	
 }
 
 .site-main .comment-navigation,


### PR DESCRIPTION
Reverse media queries to use min-width instead of max-width, taking a
mobile-first approach to the navigation menu. It displays as the
default, and disappears at widths above 600px.
