### PR TITLE
Mobile-first menu

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -71,7 +71,7 @@
 	display: none;
 }
 
-@media screen and (min-width: 600px) {
+@media screen and (min-width: 37.5em) {
 
 	.menu-toggle {
 		display: none;

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -62,19 +62,24 @@
 }
 
 /* Small menu. */
-.menu-toggle {
+.menu-toggle,
+.main-navigation.toggled .nav-menu {
+	display: block;
+}
+
+.main-navigation ul {
 	display: none;
 }
 
-@media screen and (max-width: 600px) {
-	.menu-toggle,
-	.main-navigation.toggled .nav-menu {
-		display: block;
-	}
+@media screen and (min-width: 600px) {
 
-	.main-navigation ul {
+	.menu-toggle {
 		display: none;
 	}
+	.main-navigation ul {
+		display: block;
+	}
+	
 }
 
 .site-main .comment-navigation,

--- a/style.css
+++ b/style.css
@@ -605,7 +605,7 @@ a:active {
 	display: none;
 }
 
-@media screen and (min-width: 600px) {
+@media screen and (min-width: 37.5em) {
 
 	.menu-toggle {
 		display: none;

--- a/style.css
+++ b/style.css
@@ -596,19 +596,24 @@ a:active {
 }
 
 /* Small menu. */
-.menu-toggle {
+.menu-toggle,
+.main-navigation.toggled .nav-menu {
+	display: block;
+}
+
+.main-navigation ul {
 	display: none;
 }
 
-@media screen and (max-width: 600px) {
-	.menu-toggle,
-	.main-navigation.toggled .nav-menu {
-		display: block;
-	}
+@media screen and (min-width: 600px) {
 
-	.main-navigation ul {
+	.menu-toggle {
 		display: none;
 	}
+	.main-navigation ul {
+		display: block;
+	}
+	
 }
 
 .site-main .comment-navigation,


### PR DESCRIPTION
Take a mobile-first approach to the main menu toggle, reversing media queries such that the default is the toggle menu, which disappears for larger screens. Also, change pixel values to ems.