### PR TITLE
Improvements for skip-link-focus-fix.js

### DIFF
--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -9,7 +9,7 @@
 			var element = document.getElementById( location.hash.substring( 1 ) );
 
 			if ( element ) {
-				if ( ! /^(?:a|select|input|button|textarea)$/i.test( element.tagName ) )
+				if ( ! ( /^(?:a|select|input|button|textarea)$/i.test( element.tagName ) || element.hasAttribute( 'tabindex' ) ) )
 					element.tabIndex = -1;
 
 				element.focus();

--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -1,7 +1,8 @@
 ( function() {
-	var is_webkit = navigator.userAgent.toLowerCase().indexOf( 'webkit' ) > -1,
-	    is_opera  = navigator.userAgent.toLowerCase().indexOf( 'opera' )  > -1,
-	    is_ie     = navigator.userAgent.toLowerCase().indexOf( 'msie' )   > -1;
+	var userAgent = navigator.userAgent.toLowerCase(),
+	    is_webkit = userAgent.indexOf( 'webkit' ) > -1,
+	    is_opera  = userAgent.indexOf( 'opera' )  > -1,
+	    is_ie     = userAgent.indexOf( 'msie' )   > -1 || userAgent.indexOf( 'trident' ) > -1;
 
 	if ( ( is_webkit || is_opera || is_ie ) && document.getElementById && window.addEventListener ) {
 		window.addEventListener( 'hashchange', function() {

--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -8,9 +8,16 @@
 		window.addEventListener( 'hashchange', function() {
 			var element = document.getElementById( location.hash.substring( 1 ) );
 
+			function cleanup() {
+				element.removeAttribute( 'tabindex' );
+				element.removeEventListener( 'blur', cleanup, false );
+			}
+
 			if ( element ) {
-				if ( ! ( /^(?:a|select|input|button|textarea)$/i.test( element.tagName ) || element.hasAttribute( 'tabindex' ) ) )
+				if ( ! ( /^(?:a|select|input|button|textarea)$/i.test( element.tagName ) || element.hasAttribute( 'tabindex' ) ) ) {
 					element.tabIndex = -1;
+					element.addEventListener( 'blur', cleanup, false );
+				}
 
 				element.focus();
 			}


### PR DESCRIPTION
These are some (somewhat slight) improvements that came up while I was looking at #543:

* fixed browser detect for IE11
* add `tabindex` only if the element doesn't have one already
* remove `tabindex` we added once the user has tabbed off

Would be nice to have this merged before working on a proper PR for #543.