### PR TITLE
Inherit box-sizing for best practice

### DIFF
--- a/sass/_reset.scss
+++ b/sass/_reset.scss
@@ -21,11 +21,12 @@ html {
 	overflow-y: scroll; /* Keeps page centered in all browsers regardless of content height */
 	-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
 	-ms-text-size-adjust:     100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
+	@include box-sizing(border-box);
 }
 *,
 *:before,
 *:after { /* apply a natural box layout model to all elements; see http://www.paulirish.com/2012/box-sizing-border-box-ftw/ */
-	@include box-sizing(border-box);
+	@include box-sizing(inherit);
 }
 body {
 	background: $color__background-body; /* Fallback for when there is no custom background color defined. */


### PR DESCRIPTION
Using inheritance allows easy override on other elements, and also it’s the best practice. [Paul Irish](http://www.paulirish.com/2012/box-sizing-border-box-ftw/) and [CSSTricks](http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/) have also switched and recommend this method.
