### PR TITLE
Double quotes for consistency

### DIFF
--- a/style.css
+++ b/style.css
@@ -603,7 +603,7 @@ a:active {
 .site-content:after,
 .site-footer:before,
 .site-footer:after {
-	content: '';
+	content: "";
 	display: table;
 }
 


### PR DESCRIPTION
`_s` uses double quotes `""` in all places except in clearings.

Examples: 
- https://github.com/Automattic/_s/blob/master/style.css#L121
- https://github.com/Automattic/_s/blob/master/style.css#L731
