### PR TITLE
Remove border-radius vendor prefix

### DIFF
--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -4,7 +4,7 @@ input[type="reset"],
 input[type="submit"] {
 	border: 1px solid;
 	border-color: $color__border-button;
-	@include border-radius(3px);
+	border-radius: 3px;
 	background: $color__background-button;
 	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), inset 0 15px 17px rgba(255, 255, 255, 0.5), inset 0 -5px 12px rgba(0, 0, 0, 0.05);
 	color: rgba(0, 0, 0, .8);

--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -28,7 +28,7 @@ input[type="search"],
 textarea {
 	color: $color__text-input;
 	border: 1px solid $color__border-input;
-	@include border-radius(3px);
+	border-radius: 3px;
 }
 
 input[type="text"]:focus,

--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -11,13 +11,6 @@
 	box-sizing: $box-model;
 }
 
-// Border radius
-@mixin border-radius($radius) {
-	background-clip: padding-box; /* stops bg color from leaking outside the border: */
-	-webkit-border-radius: $radius;
-	border-radius: $radius;
-}
-
 // Center block
 @mixin center-block {
 	display: block;

--- a/sass/modules/_accessibility.scss
+++ b/sass/modules/_accessibility.scss
@@ -10,7 +10,7 @@
 	&:active,
 	&:focus {
 		background-color: $color__background-screen;
-		@include border-radius(3px);
+		border-radius: 3px;
 		box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 		clip: auto !important;
 		color: $color__text-screen;

--- a/style.css
+++ b/style.css
@@ -204,7 +204,9 @@ code,
 kbd,
 tt,
 var {
-	font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+	font-size: 15px;
+	font-size: 1.5rem;
+	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 }
 
 abbr,
@@ -556,6 +558,7 @@ a:active {
 	color: #21759b;
 	display: block;
 	font-size: 14px;
+	font-size: 1.4rem;
 	font-weight: bold;
 	height: auto;
 	left: 5px;


### PR DESCRIPTION
Border radius in Chrome is widely [supported](http://caniuse.com/#search=border-radius), there is no need add a vender prefix for webkit.
