### PR TITLE
Use sprintf for translation instead of including html in the translation strings

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -22,11 +22,11 @@ function _s_paging_nav() {
 		<div class="nav-links">
 
 			<?php if ( get_next_posts_link() ) : ?>
-			<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ) ); ?></div>
+			<div class="nav-previous"><?php next_posts_link( sprintf( '<span class="meta-nav">&larr;</span> %s', __( 'Older posts', '_s' ) ) ); ?></div>
 			<?php endif; ?>
 
 			<?php if ( get_previous_posts_link() ) : ?>
-			<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ) ); ?></div>
+			<div class="nav-next"><?php previous_posts_link( sprintf( '%s <span class="meta-nav">&rarr;</span>', __( 'Newer posts', '_s' ) ) ); ?></div>
 			<?php endif; ?>
 
 		</div><!-- .nav-links -->


### PR DESCRIPTION
Would it make sense to exclude the HTML from the translation strings when possible? It would reduce the possibility of translator error with a typo of the class name and possibly reduce strings, if the same text is used elsewhere.
