### PR TITLE
Disallow zoom on mobile so that visitors can enlarge content

### DIFF
--- a/header.php
+++ b/header.php
@@ -10,7 +10,13 @@
 <html <?php language_attributes(); ?>>
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<?php 
+/* 	Limiting or disallowing zoom on mobile prevents visitors from
+*	being able to enlarge your content (text or images) for a better reading
+*	or viewing experience. 
+*/ 
+?>
+<meta name="viewport" content="width=device-width" />
 <title><?php wp_title( '|', true, 'right' ); ?></title>
 <link rel="profile" href="http://gmpg.org/xfn/11">
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">


### PR DESCRIPTION
Change the viewport meta tag from `content="width=device-width, initial-scale=1"` to `content="width=device-width"`

The reason for this is that limiting or disallowing zoom on mobile prevents visitors from being able to enlarge your content (text or images) for a better reading or viewing experience. 
