### PR TITLE
Update links to those relevant to themes

### DIFF
--- a/languages/readme.txt
+++ b/languages/readme.txt
@@ -2,5 +2,6 @@ Place your theme language files in this directory.
 
 Please visit the following links to learn more about translating WordPress themes:
 
-http://codex.wordpress.org/Translating_WordPress
+http://codex.wordpress.org/WordPress_in_Your_Language
+https://make.wordpress.org/docs/theme-developer-handbook/part-two-theme-functionality/localization/
 http://codex.wordpress.org/Function_Reference/load_theme_textdomain


### PR DESCRIPTION
The link "http://codex.wordpress.org/Translating_WordPress" is more centered around tranlsting WordPress and not themes.
