### PR TITLE
Load parent styles when child theme is activated

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -92,6 +92,10 @@ add_action( 'widgets_init', '_s_widgets_init' );
  * Enqueue scripts and styles.
  */
 function _s_scripts() {
+	if ( is_child_theme() ) {
+		wp_enqueue_style( '_s-parent-style', get_template_directory_uri() . '/style.css' );
+	}
+
 	wp_enqueue_style( '_s-style', get_stylesheet_uri() );
 
 	wp_enqueue_script( '_s-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20120206', true );


### PR DESCRIPTION
 After https://github.com/Automattic/_s/issues/635 I had another look at how the styles should be loaded when a child theme has been activated.

I spoke to @justintadlock and he mentioned that Hybrid-Core has been doing this for some time without any issues.

Responsive switched to this method soon after I wrote [an article](https://ulrich.pogson.ch/how-to-load-the-parent-styles-in-child-themes) on it last year and we have had no complaints.

The pros:
- The child theme does not require an @import and it just works with a blank style.css file.
- Not requiring the @import should bring some performance gains.
