### PR TITLE
Inheriting box sizing v2

### DIFF
--- a/sass/_reset.scss
+++ b/sass/_reset.scss
@@ -21,11 +21,13 @@ html {
 	overflow-y: scroll; /* Keeps page centered in all browsers regardless of content height */
 	-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
 	-ms-text-size-adjust:     100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
+	/* apply a natural box layout model to all elements; see http://www.paulirish.com/2012/box-sizing-border-box-ftw/ */
+	@include box-sizing(border-box);
 }
 *,
 *:before,
-*:after { /* apply a natural box layout model to all elements; see http://www.paulirish.com/2012/box-sizing-border-box-ftw/ */
-	@include box-sizing(border-box);
+*:after { 
+	box-sizing: inherit; /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
 }
 body {
 	background: $color__background-body; /* Fallback for when there is no custom background color defined. */

--- a/style.css
+++ b/style.css
@@ -81,7 +81,7 @@ html {
 *,
 *:before,
 *:after { 
-        box-sizing: inherit; /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
+	box-sizing: inherit; /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
 }
 
 body {


### PR DESCRIPTION
New patch for inheriting box sizing (replaces the now closed #630). Removed my previous "unclean" patch and replaced with this one which only includes the actual changes, no historical data.

This patch is based on the same idea as #609 but also has a patch for SASS to make the two stylesheets consistent.
## Background:

This patch improves box-sizing in accordance with http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ and http://blog.teamtreehouse.com/box-sizing-secret-simple-css-layouts#comment-50223 to allow for easier changes and alterations of the property in components and plugins that rely on other property settings.

Works the same as before, but improves functionality marginally and is considered the new best-practice approach.
