### PR TITLE
Check DOING_AUTOSAVE before flushing transients

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -250,6 +250,9 @@ function _s_categorized_blog() {
  * Flush out the transients used in _s_categorized_blog.
  */
 function _s_category_transient_flusher() {
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
 	// Like, beat it. Dig?
 	delete_transient( '_s_categories' );
 }


### PR DESCRIPTION
So that we don’t flush transients more often than necessary.

Fixes #646
