### PR TITLE
Remove Custom Header and Background Admin Callbacks

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -19,8 +19,6 @@
  * Set up the WordPress core custom header feature.
  *
  * @uses _s_header_style()
- * @uses _s_admin_header_style()
- * @uses _s_admin_header_image()
  */
 function _s_custom_header_setup() {
 	add_theme_support( 'custom-header', apply_filters( '_s_custom_header_args', array(
@@ -30,8 +28,6 @@ function _s_custom_header_setup() {
 		'height'                 => 250,
 		'flex-height'            => true,
 		'wp-head-callback'       => '_s_header_style',
-		'admin-head-callback'    => '_s_admin_header_style',
-		'admin-preview-callback' => '_s_admin_header_image',
 	) ) );
 }
 add_action( 'after_setup_theme', '_s_custom_header_setup' );
@@ -76,51 +72,3 @@ function _s_header_style() {
 	<?php
 }
 endif; // _s_header_style
-
-if ( ! function_exists( '_s_admin_header_style' ) ) :
-/**
- * Styles the header image displayed on the Appearance > Header admin panel.
- *
- * @see _s_custom_header_setup().
- */
-function _s_admin_header_style() {
-?>
-	<style type="text/css">
-		.appearance_page_custom-header #headimg {
-			border: none;
-		}
-		#headimg h1,
-		#desc {
-		}
-		#headimg h1 {
-		}
-		#headimg h1 a {
-		}
-		#desc {
-		}
-		#headimg img {
-		}
-	</style>
-<?php
-}
-endif; // _s_admin_header_style
-
-if ( ! function_exists( '_s_admin_header_image' ) ) :
-/**
- * Custom header image markup displayed on the Appearance > Header admin panel.
- *
- * @see _s_custom_header_setup().
- */
-function _s_admin_header_image() {
-	$style = sprintf( ' style="color:#%s;"', get_header_textcolor() );
-?>
-	<div id="headimg">
-		<h1 class="displaying-header-text"><a id="name"<?php echo $style; ?> onclick="return false;" href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
-		<div class="displaying-header-text" id="desc"<?php echo $style; ?>><?php bloginfo( 'description' ); ?></div>
-		<?php if ( get_header_image() ) : ?>
-		<img src="<?php header_image(); ?>" alt="">
-		<?php endif; ?>
-	</div>
-<?php
-}
-endif; // _s_admin_header_image


### PR DESCRIPTION
With [#25571](https://core.trac.wordpress.org/ticket/25571) landing in Core, the Custom Header page under Appearance will now redirect to the corresponding section in the Customizer.

This allows us to remove the callback functions that were used to style the old Custom Header page.