### PR TITLE
For rem value of font-size mixin, first divide $sizeValue by 1.6 ...

### DIFF
--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -1,7 +1,7 @@
 // Rem output with px fallback
 @mixin font-size($sizeValue: 1.6) {
 	font-size: ($sizeValue * 10) + px;
-	font-size: $sizeValue + rem;
+	font-size: ($sizeValue / 1.6 ) + rem; // Divide by 1.6, because 16px = 1rem, by default
 }
 
 // Center block


### PR DESCRIPTION
...since in browsers, 1rem is equal to 16px

if 1.6 is passed, we'd expect 1rem (1.6/1.6) = 1rem
if we passed 2.4 expecting 24px, we end up with 1.5 rem. 16 \* 1.5 = 24px.

Old method would essentially add:
font-size: 16px;
font-size: 25.6px (because 1.6 rem = 16px \* 1.6)
