### PR TITLE
Add .archive .byline to display authors name

### DIFF
--- a/style.css
+++ b/style.css
@@ -646,6 +646,7 @@ a:active {
 	display: none;
 }
 
+.blog .byline,
 .single .byline,
 .archive .byline,
 .group-blog .byline {


### PR DESCRIPTION
Proposing to add `.archive .byline {}` so that Categories, Author etc can have the authors name instead of just `Posted on November 28, 2014`. Not sure if there is any background behind it or a reason why we won't show this across the theme :)

Update: Well, this did not workout well, we need to add one more `.blog .byline {}` and now this is complete. 
