### PR TITLE
Header: Made aria-controls refer to an ID instead of a class

### DIFF
--- a/header.php
+++ b/header.php
@@ -28,8 +28,8 @@
 		</div><!-- .site-branding -->
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">
-			<button class="menu-toggle" aria-controls="menu" aria-expanded="false"><?php _e( 'Primary Menu', '_s' ); ?></button>
-			<?php wp_nav_menu( array( 'theme_location' => 'primary' ) ); ?>
+			<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php _e( 'Primary Menu', '_s' ); ?></button>
+			<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu' ) ); ?>
 		</nav><!-- #site-navigation -->
 	</header><!-- #masthead -->
 


### PR DESCRIPTION
The ```aria-controls``` attribute that was added to the menu-toggle button in https://github.com/Automattic/_s/commit/e142af3a2720e38179e294181562c22842a68c3e refers to the class of the primary menu. According to the specs it should refer to an ID (http://www.w3.org/TR/wai-aria/states_and_properties#aria-controls).

Ref #545 