### PR TITLE
Make sure entry titles don't overflow content area

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -6,6 +6,11 @@
 	margin: 0 0 1.5em;
 }
 
+.entry-title {
+	-ms-word-wrap: break-word;
+	word-wrap: break-word;
+}
+
 .byline,
 .updated:not(.published){
 	display: none;

--- a/style.css
+++ b/style.css
@@ -641,6 +641,11 @@ a:active {
 	margin: 0 0 1.5em;
 }
 
+.entry-title {
+	-ms-word-wrap: break-word;
+	word-wrap: break-word;
+}
+
 .byline,
 .updated:not(.published) {
 	display: none;


### PR DESCRIPTION
As per the theme unit test data, titles shouldn't overflow the content area. It suggests adding word-wrap: break-word; to support non-breaking text. This pull request basically just adds that recommended code to _s.