### PR TITLE
Fix error with travis

### DIFF
--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -8,6 +8,8 @@
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">
 		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
+		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
 
 		<exclude name="WordPress.XSS.EscapeOutput" />
 		<exclude name="WordPress.WhiteSpace.ScopeIndent.Incorrect" />

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -53,7 +53,7 @@ function _s_post_nav() {
 		<div class="nav-links">
 			<?php
 				previous_post_link( '<div class="nav-previous">%link</div>', _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ) );
-				next_post_link(     '<div class="nav-next">%link</div>',     _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ) );
+				next_post_link( '<div class="nav-next">%link</div>', _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link', '_s' ) );
 			?>
 		</div><!-- .nav-links -->
 	</nav><!-- .navigation -->


### PR DESCRIPTION
It will fix error that caused by updating php-codesniffer.

Anyway, I thought version of the phpcs should be locked like following.

```
$ composer global require "squizlabs/php_codesniffer=2.0.0"
```

But WordPress rule will be update again in the future and it doesn't have tags.
I couldn't decide lock or not ...
