### PR TITLE
Add the_posts_navigation() and the_post_navigation()

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -34,7 +34,12 @@ get_header(); ?>
 
 			<?php endwhile; ?>
 
-			<?php _s_paging_nav(); ?>
+			<?php
+				the_posts_navigation( array(
+					'prev_text' => __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ),
+					'next_text' => __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ),
+				) );
+			?>
 
 		<?php else : ?>
 

--- a/archive.php
+++ b/archive.php
@@ -34,12 +34,7 @@ get_header(); ?>
 
 			<?php endwhile; ?>
 
-			<?php
-				the_posts_navigation( array(
-					'prev_text' => __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ),
-					'next_text' => __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ),
-				) );
-			?>
+			<?php the_posts_navigation(); ?>
 
 		<?php else : ?>
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -61,7 +61,7 @@ function the_post_navigation() {
 			?>
 		</div><!-- .nav-links -->
 	</nav><!-- .navigation -->
-<?php
+	<?php
 }
 endif;
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -24,11 +24,11 @@ function the_posts_navigation() {
 		<div class="nav-links">
 
 			<?php if ( get_next_posts_link() ) : ?>
-			<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ) ); ?></div>
+			<div class="nav-previous"><?php next_posts_link( __( 'Older posts', '_s' ) ); ?></div>
 			<?php endif; ?>
 
 			<?php if ( get_previous_posts_link() ) : ?>
-			<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ) ); ?></div>
+			<div class="nav-next"><?php previous_posts_link( __( 'Newer posts', '_s' ) ); ?></div>
 			<?php endif; ?>
 
 		</div><!-- .nav-links -->
@@ -56,8 +56,8 @@ function the_post_navigation() {
 		<h2 class="screen-reader-text"><?php _e( 'Post navigation', '_s' ); ?></h2>
 		<div class="nav-links">
 			<?php
-				previous_post_link( '<div class="nav-previous">%link</div>', _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ) );
-				next_post_link( '<div class="nav-next">%link</div>',     _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ) );
+				previous_post_link( '<div class="nav-previous">%link</div>', '%title' );
+				next_post_link( '<div class="nav-next">%link</div>', '%title' );
 			?>
 		</div><!-- .nav-links -->
 	</nav><!-- .navigation -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -10,54 +10,72 @@
 if ( ! function_exists( '_s_paging_nav' ) ) :
 /**
  * Display navigation to next/previous set of posts when applicable.
+ *
+ * @todo Change this function when WordPress 4.3 is released.
  */
 function _s_paging_nav() {
-	// Don't print empty markup if there's only one page.
-	if ( $GLOBALS['wp_query']->max_num_pages < 2 ) {
-		return;
-	}
-	?>
-	<nav class="navigation paging-navigation" role="navigation">
-		<h1 class="screen-reader-text"><?php _e( 'Posts navigation', '_s' ); ?></h1>
-		<div class="nav-links">
+	if ( function_exists( 'the_posts_navigation' ) ) {
+		the_posts_navigation( array(
+			'prev_text' => __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ),
+			'next_text' => __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ),
+		) );
+	} else {
+		// Don't print empty markup if there's only one page.
+		if ( $GLOBALS['wp_query']->max_num_pages < 2 ) {
+			return;
+		}
+		?>
+		<nav class="navigation posts-navigation" role="navigation">
+			<h2 class="screen-reader-text"><?php _e( 'Posts navigation', '_s' ); ?></h2>
+			<div class="nav-links">
 
-			<?php if ( get_next_posts_link() ) : ?>
-			<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ) ); ?></div>
-			<?php endif; ?>
-
-			<?php if ( get_previous_posts_link() ) : ?>
-			<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ) ); ?></div>
-			<?php endif; ?>
-
-		</div><!-- .nav-links -->
-	</nav><!-- .navigation -->
+				<?php if ( get_next_posts_link() ) : ?>
+				<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ) ); ?></div>
+				<?php endif; ?>
+	
+				<?php if ( get_previous_posts_link() ) : ?>
+				<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ) ); ?></div>
+				<?php endif; ?>
+	
+			</div><!-- .nav-links -->
+		</nav><!-- .navigation -->
 	<?php
+	}
 }
 endif;
 
 if ( ! function_exists( '_s_post_nav' ) ) :
 /**
  * Display navigation to next/previous post when applicable.
+ *
+ * @todo Change this function when WordPress 4.3 is released.
  */
 function _s_post_nav() {
-	// Don't print empty markup if there's nowhere to navigate.
-	$previous = ( is_attachment() ) ? get_post( get_post()->post_parent ) : get_adjacent_post( false, '', true );
-	$next     = get_adjacent_post( false, '', false );
+	if ( function_exists( 'the_post_navigation' ) ) {
+		the_post_navigation( array(
+			'prev_text' => _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ),
+			'next_text' => _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ),
+		) );
+	} else {
+		// Don't print empty markup if there's nowhere to navigate.
+		$previous = ( is_attachment() ) ? get_post( get_post()->post_parent ) : get_adjacent_post( false, '', true );
+		$next     = get_adjacent_post( false, '', false );
 
-	if ( ! $next && ! $previous ) {
-		return;
-	}
+		if ( ! $next && ! $previous ) {
+			return;
+		}
 	?>
-	<nav class="navigation post-navigation" role="navigation">
-		<h1 class="screen-reader-text"><?php _e( 'Post navigation', '_s' ); ?></h1>
-		<div class="nav-links">
-			<?php
-				previous_post_link( '<div class="nav-previous">%link</div>', _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ) );
-				next_post_link(     '<div class="nav-next">%link</div>',     _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ) );
-			?>
-		</div><!-- .nav-links -->
-	</nav><!-- .navigation -->
+		<nav class="navigation post-navigation" role="navigation">
+			<h2 class="screen-reader-text"><?php _e( 'Post navigation', '_s' ); ?></h2>
+			<div class="nav-links">
+				<?php
+					previous_post_link( '<div class="nav-previous">%link</div>', _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ) );
+					next_post_link( '<div class="nav-next">%link</div>',     _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ) );
+				?>
+			</div><!-- .nav-links -->
+		</nav><!-- .navigation -->
 	<?php
+	}
 }
 endif;
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -33,7 +33,7 @@ function the_posts_navigation() {
 
 		</div><!-- .nav-links -->
 	</nav><!-- .navigation -->
-<?php
+	<?php
 }
 endif;
 
@@ -51,7 +51,7 @@ function the_post_navigation() {
 	if ( ! $next && ! $previous ) {
 		return;
 	}
-?>
+	?>
 	<nav class="navigation post-navigation" role="navigation">
 		<h2 class="screen-reader-text"><?php _e( 'Post navigation', '_s' ); ?></h2>
 		<div class="nav-links">

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -7,75 +7,61 @@
  * @package _s
  */
 
-if ( ! function_exists( '_s_paging_nav' ) ) :
+if ( ! function_exists( 'the_posts_navigation' ) ) :
 /**
  * Display navigation to next/previous set of posts when applicable.
  *
- * @todo Change this function when WordPress 4.3 is released.
+ * @todo Remove this function when WordPress 4.3 is released.
  */
-function _s_paging_nav() {
-	if ( function_exists( 'the_posts_navigation' ) ) {
-		the_posts_navigation( array(
-			'prev_text' => __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ),
-			'next_text' => __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ),
-		) );
-	} else {
-		// Don't print empty markup if there's only one page.
-		if ( $GLOBALS['wp_query']->max_num_pages < 2 ) {
-			return;
-		}
-		?>
-		<nav class="navigation posts-navigation" role="navigation">
-			<h2 class="screen-reader-text"><?php _e( 'Posts navigation', '_s' ); ?></h2>
-			<div class="nav-links">
-
-				<?php if ( get_next_posts_link() ) : ?>
-				<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ) ); ?></div>
-				<?php endif; ?>
-	
-				<?php if ( get_previous_posts_link() ) : ?>
-				<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ) ); ?></div>
-				<?php endif; ?>
-	
-			</div><!-- .nav-links -->
-		</nav><!-- .navigation -->
-	<?php
+function the_posts_navigation() {
+	// Don't print empty markup if there's only one page.
+	if ( $GLOBALS['wp_query']->max_num_pages < 2 ) {
+		return;
 	}
+	?>
+	<nav class="navigation posts-navigation" role="navigation">
+		<h2 class="screen-reader-text"><?php _e( 'Posts navigation', '_s' ); ?></h2>
+		<div class="nav-links">
+
+			<?php if ( get_next_posts_link() ) : ?>
+			<div class="nav-previous"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ) ); ?></div>
+			<?php endif; ?>
+
+			<?php if ( get_previous_posts_link() ) : ?>
+			<div class="nav-next"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ) ); ?></div>
+			<?php endif; ?>
+
+		</div><!-- .nav-links -->
+	</nav><!-- .navigation -->
+<?php
 }
 endif;
 
-if ( ! function_exists( '_s_post_nav' ) ) :
+if ( ! function_exists( 'the_post_navigation' ) ) :
 /**
  * Display navigation to next/previous post when applicable.
  *
- * @todo Change this function when WordPress 4.3 is released.
+ * @todo Remove this function when WordPress 4.3 is released.
  */
-function _s_post_nav() {
-	if ( function_exists( 'the_post_navigation' ) ) {
-		the_post_navigation( array(
-			'prev_text' => _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ),
-			'next_text' => _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ),
-		) );
-	} else {
-		// Don't print empty markup if there's nowhere to navigate.
-		$previous = ( is_attachment() ) ? get_post( get_post()->post_parent ) : get_adjacent_post( false, '', true );
-		$next     = get_adjacent_post( false, '', false );
+function the_post_navigation() {
+	// Don't print empty markup if there's nowhere to navigate.
+	$previous = ( is_attachment() ) ? get_post( get_post()->post_parent ) : get_adjacent_post( false, '', true );
+	$next     = get_adjacent_post( false, '', false );
 
-		if ( ! $next && ! $previous ) {
-			return;
-		}
-	?>
-		<nav class="navigation post-navigation" role="navigation">
-			<h2 class="screen-reader-text"><?php _e( 'Post navigation', '_s' ); ?></h2>
-			<div class="nav-links">
-				<?php
-					previous_post_link( '<div class="nav-previous">%link</div>', _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ) );
-					next_post_link( '<div class="nav-next">%link</div>',     _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ) );
-				?>
-			</div><!-- .nav-links -->
-		</nav><!-- .navigation -->
-	<?php
+	if ( ! $next && ! $previous ) {
+		return;
 	}
+?>
+	<nav class="navigation post-navigation" role="navigation">
+		<h2 class="screen-reader-text"><?php _e( 'Post navigation', '_s' ); ?></h2>
+		<div class="nav-links">
+			<?php
+				previous_post_link( '<div class="nav-previous">%link</div>', _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ) );
+				next_post_link( '<div class="nav-next">%link</div>',     _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ) );
+			?>
+		</div><!-- .nav-links -->
+	</nav><!-- .navigation -->
+<?php
 }
 endif;
 

--- a/index.php
+++ b/index.php
@@ -31,12 +31,7 @@ get_header(); ?>
 
 			<?php endwhile; ?>
 
-			<?php
-				the_posts_navigation( array(
-					'prev_text' => __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ),
-					'next_text' => __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ),
-				) );
-			?>
+			<?php the_posts_navigation(); ?>
 
 		<?php else : ?>
 

--- a/index.php
+++ b/index.php
@@ -31,7 +31,12 @@ get_header(); ?>
 
 			<?php endwhile; ?>
 
-			<?php _s_paging_nav(); ?>
+			<?php
+				the_posts_navigation( array(
+					'prev_text' => __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ),
+					'next_text' => __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ),
+				) );
+			?>
 
 		<?php else : ?>
 

--- a/languages/_s.pot
+++ b/languages/_s.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: _s 1.0-wpcom\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/theme/_s\n"
-"POT-Creation-Date: 2014-12-03 09:43:15+00:00\n"
+"POT-Creation-Date: 2014-12-19 01:28:13+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Pages:"
 msgstr ""
 
-#: content-page.php:25 inc/template-tags.php:122
+#: content-page.php:25 inc/template-tags.php:140
 msgid "Edit"
 msgstr ""
 
@@ -111,163 +111,163 @@ msgstr ""
 msgid "Page %s"
 msgstr ""
 
-#: inc/template-tags.php:21
-msgid "Posts navigation"
-msgstr ""
-
-#: inc/template-tags.php:25
+#: inc/template-tags.php:19 inc/template-tags.php:33
 msgid "<span class=\"meta-nav\">&larr;</span> Older posts"
 msgstr ""
 
-#: inc/template-tags.php:29
+#: inc/template-tags.php:20 inc/template-tags.php:37
 msgid "Newer posts <span class=\"meta-nav\">&rarr;</span>"
 msgstr ""
 
-#: inc/template-tags.php:52
-msgid "Post navigation"
+#: inc/template-tags.php:29
+msgid "Posts navigation"
 msgstr ""
 
-#: inc/template-tags.php:55
+#: inc/template-tags.php:56 inc/template-tags.php:72
 msgctxt "Previous post link"
 msgid "<span class=\"meta-nav\">&larr;</span>&nbsp;%title"
 msgstr ""
 
-#: inc/template-tags.php:56
+#: inc/template-tags.php:57 inc/template-tags.php:73
 msgctxt "Next post link"
 msgid "%title&nbsp;<span class=\"meta-nav\">&rarr;</span>"
 msgstr ""
 
-#: inc/template-tags.php:82
+#: inc/template-tags.php:69
+msgid "Post navigation"
+msgstr ""
+
+#: inc/template-tags.php:100
 msgctxt "post date"
 msgid "Posted on %s"
 msgstr ""
 
-#: inc/template-tags.php:87
+#: inc/template-tags.php:105
 msgctxt "post author"
 msgid "by %s"
 msgstr ""
 
 #. translators: used between list items, there is a space after the comma
 
-#: inc/template-tags.php:104 inc/template-tags.php:110
+#: inc/template-tags.php:122 inc/template-tags.php:128
 msgid ", "
 msgstr ""
 
-#: inc/template-tags.php:106
+#: inc/template-tags.php:124
 msgid "Posted in %1$s"
 msgstr ""
 
-#: inc/template-tags.php:112
+#: inc/template-tags.php:130
 msgid "Tagged %1$s"
 msgstr ""
 
-#: inc/template-tags.php:118
+#: inc/template-tags.php:136
 msgid "Leave a comment"
 msgstr ""
 
-#: inc/template-tags.php:118
+#: inc/template-tags.php:136
 msgid "1 Comment"
 msgstr ""
 
-#: inc/template-tags.php:118
+#: inc/template-tags.php:136
 msgid "% Comments"
 msgstr ""
 
-#: inc/template-tags.php:139
+#: inc/template-tags.php:157
 msgid "Category: %s"
 msgstr ""
 
-#: inc/template-tags.php:141
+#: inc/template-tags.php:159
 msgid "Tag: %s"
 msgstr ""
 
-#: inc/template-tags.php:143
+#: inc/template-tags.php:161
 msgid "Author: %s"
 msgstr ""
 
-#: inc/template-tags.php:145
+#: inc/template-tags.php:163
 msgid "Year: %s"
 msgstr ""
 
-#: inc/template-tags.php:145
+#: inc/template-tags.php:163
 msgctxt "yearly archives date format"
 msgid "Y"
 msgstr ""
 
-#: inc/template-tags.php:147
+#: inc/template-tags.php:165
 msgid "Month: %s"
 msgstr ""
 
-#: inc/template-tags.php:147
+#: inc/template-tags.php:165
 msgctxt "monthly archives date format"
 msgid "F Y"
 msgstr ""
 
-#: inc/template-tags.php:149
+#: inc/template-tags.php:167
 msgid "Day: %s"
 msgstr ""
 
-#: inc/template-tags.php:149
+#: inc/template-tags.php:167
 msgctxt "daily archives date format"
 msgid "F j, Y"
 msgstr ""
 
-#: inc/template-tags.php:151
+#: inc/template-tags.php:169
 msgctxt "post format archive title"
 msgid "Asides"
 msgstr ""
 
-#: inc/template-tags.php:153
+#: inc/template-tags.php:171
 msgctxt "post format archive title"
 msgid "Galleries"
 msgstr ""
 
-#: inc/template-tags.php:155
+#: inc/template-tags.php:173
 msgctxt "post format archive title"
 msgid "Images"
 msgstr ""
 
-#: inc/template-tags.php:157
+#: inc/template-tags.php:175
 msgctxt "post format archive title"
 msgid "Videos"
 msgstr ""
 
-#: inc/template-tags.php:159
+#: inc/template-tags.php:177
 msgctxt "post format archive title"
 msgid "Quotes"
 msgstr ""
 
-#: inc/template-tags.php:161
+#: inc/template-tags.php:179
 msgctxt "post format archive title"
 msgid "Links"
 msgstr ""
 
-#: inc/template-tags.php:163
+#: inc/template-tags.php:181
 msgctxt "post format archive title"
 msgid "Statuses"
 msgstr ""
 
-#: inc/template-tags.php:165
+#: inc/template-tags.php:183
 msgctxt "post format archive title"
 msgid "Audio"
 msgstr ""
 
-#: inc/template-tags.php:167
+#: inc/template-tags.php:185
 msgctxt "post format archive title"
 msgid "Chats"
 msgstr ""
 
-#: inc/template-tags.php:169
+#: inc/template-tags.php:187
 msgid "Archives: %s"
 msgstr ""
 
 #. translators: 1: Taxonomy singular name, 2: Current taxonomy term
 
-#: inc/template-tags.php:173
+#: inc/template-tags.php:191
 msgid "%1$s: %2$s"
 msgstr ""
 
-#: inc/template-tags.php:175
+#: inc/template-tags.php:193
 msgid "Archives"
 msgstr ""
 

--- a/languages/_s.pot
+++ b/languages/_s.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: _s 1.0.0\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/tags/_s\n"
-"POT-Creation-Date: 2015-01-05 18:17:28+00:00\n"
+"POT-Creation-Date: 2015-01-06 02:24:02+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -28,14 +28,6 @@ msgstr ""
 
 #: 404.php:44
 msgid "Try looking in the monthly archives. %1$s"
-msgstr ""
-
-#: archive.php:39 inc/template-tags.php:27 index.php:36 search.php:35
-msgid "<span class=\"meta-nav\">&larr;</span> Older posts"
-msgstr ""
-
-#: archive.php:40 inc/template-tags.php:31 index.php:37 search.php:36
-msgid "Newer posts <span class=\"meta-nav\">&rarr;</span>"
 msgstr ""
 
 #: comments.php:28
@@ -123,18 +115,16 @@ msgstr ""
 msgid "Posts navigation"
 msgstr ""
 
+#: inc/template-tags.php:27
+msgid "Older posts"
+msgstr ""
+
+#: inc/template-tags.php:31
+msgid "Newer posts"
+msgstr ""
+
 #: inc/template-tags.php:56
 msgid "Post navigation"
-msgstr ""
-
-#: inc/template-tags.php:59 single.php:19
-msgctxt "Previous post link"
-msgid "<span class=\"meta-nav\">&larr;</span>&nbsp;%title"
-msgstr ""
-
-#: inc/template-tags.php:60 single.php:20
-msgctxt "Next post link"
-msgid "%title&nbsp;<span class=\"meta-nav\">&rarr;</span>"
 msgstr ""
 
 #: inc/template-tags.php:86

--- a/languages/_s.pot
+++ b/languages/_s.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2014 Automattic
+# Copyright (C) 2015 Automattic
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: _s 1.0-wpcom\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/support/theme/_s\n"
-"POT-Creation-Date: 2014-12-19 01:28:13+00:00\n"
+"Project-Id-Version: _s 1.0.0\n"
+"Report-Msgid-Bugs-To: http://wordpress.org/tags/_s\n"
+"POT-Creation-Date: 2015-01-05 18:17:28+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2014-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2015-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 
@@ -28,6 +28,14 @@ msgstr ""
 
 #: 404.php:44
 msgid "Try looking in the monthly archives. %1$s"
+msgstr ""
+
+#: archive.php:39 inc/template-tags.php:27 index.php:36 search.php:35
+msgid "<span class=\"meta-nav\">&larr;</span> Older posts"
+msgstr ""
+
+#: archive.php:40 inc/template-tags.php:31 index.php:37 search.php:36
+msgid "Newer posts <span class=\"meta-nav\">&rarr;</span>"
 msgstr ""
 
 #: comments.php:28
@@ -73,7 +81,7 @@ msgstr ""
 msgid "Pages:"
 msgstr ""
 
-#: content-page.php:25 inc/template-tags.php:140
+#: content-page.php:25 inc/template-tags.php:126
 msgid "Edit"
 msgstr ""
 
@@ -111,163 +119,154 @@ msgstr ""
 msgid "Page %s"
 msgstr ""
 
-#: inc/template-tags.php:19 inc/template-tags.php:33
-msgid "<span class=\"meta-nav\">&larr;</span> Older posts"
-msgstr ""
-
-#: inc/template-tags.php:20 inc/template-tags.php:37
-msgid "Newer posts <span class=\"meta-nav\">&rarr;</span>"
-msgstr ""
-
-#: inc/template-tags.php:29
+#: inc/template-tags.php:23
 msgid "Posts navigation"
 msgstr ""
 
-#: inc/template-tags.php:56 inc/template-tags.php:72
+#: inc/template-tags.php:56
+msgid "Post navigation"
+msgstr ""
+
+#: inc/template-tags.php:59 single.php:19
 msgctxt "Previous post link"
 msgid "<span class=\"meta-nav\">&larr;</span>&nbsp;%title"
 msgstr ""
 
-#: inc/template-tags.php:57 inc/template-tags.php:73
+#: inc/template-tags.php:60 single.php:20
 msgctxt "Next post link"
 msgid "%title&nbsp;<span class=\"meta-nav\">&rarr;</span>"
 msgstr ""
 
-#: inc/template-tags.php:69
-msgid "Post navigation"
-msgstr ""
-
-#: inc/template-tags.php:100
+#: inc/template-tags.php:86
 msgctxt "post date"
 msgid "Posted on %s"
 msgstr ""
 
-#: inc/template-tags.php:105
+#: inc/template-tags.php:91
 msgctxt "post author"
 msgid "by %s"
 msgstr ""
 
 #. translators: used between list items, there is a space after the comma
-
-#: inc/template-tags.php:122 inc/template-tags.php:128
+#: inc/template-tags.php:108 inc/template-tags.php:114
 msgid ", "
 msgstr ""
 
-#: inc/template-tags.php:124
+#: inc/template-tags.php:110
 msgid "Posted in %1$s"
 msgstr ""
 
-#: inc/template-tags.php:130
+#: inc/template-tags.php:116
 msgid "Tagged %1$s"
 msgstr ""
 
-#: inc/template-tags.php:136
+#: inc/template-tags.php:122
 msgid "Leave a comment"
 msgstr ""
 
-#: inc/template-tags.php:136
+#: inc/template-tags.php:122
 msgid "1 Comment"
 msgstr ""
 
-#: inc/template-tags.php:136
+#: inc/template-tags.php:122
 msgid "% Comments"
 msgstr ""
 
-#: inc/template-tags.php:157
+#: inc/template-tags.php:143
 msgid "Category: %s"
 msgstr ""
 
-#: inc/template-tags.php:159
+#: inc/template-tags.php:145
 msgid "Tag: %s"
 msgstr ""
 
-#: inc/template-tags.php:161
+#: inc/template-tags.php:147
 msgid "Author: %s"
 msgstr ""
 
-#: inc/template-tags.php:163
+#: inc/template-tags.php:149
 msgid "Year: %s"
 msgstr ""
 
-#: inc/template-tags.php:163
+#: inc/template-tags.php:149
 msgctxt "yearly archives date format"
 msgid "Y"
 msgstr ""
 
-#: inc/template-tags.php:165
+#: inc/template-tags.php:151
 msgid "Month: %s"
 msgstr ""
 
-#: inc/template-tags.php:165
+#: inc/template-tags.php:151
 msgctxt "monthly archives date format"
 msgid "F Y"
 msgstr ""
 
-#: inc/template-tags.php:167
+#: inc/template-tags.php:153
 msgid "Day: %s"
 msgstr ""
 
-#: inc/template-tags.php:167
+#: inc/template-tags.php:153
 msgctxt "daily archives date format"
 msgid "F j, Y"
 msgstr ""
 
-#: inc/template-tags.php:169
+#: inc/template-tags.php:155
 msgctxt "post format archive title"
 msgid "Asides"
 msgstr ""
 
-#: inc/template-tags.php:171
+#: inc/template-tags.php:157
 msgctxt "post format archive title"
 msgid "Galleries"
 msgstr ""
 
-#: inc/template-tags.php:173
+#: inc/template-tags.php:159
 msgctxt "post format archive title"
 msgid "Images"
 msgstr ""
 
-#: inc/template-tags.php:175
+#: inc/template-tags.php:161
 msgctxt "post format archive title"
 msgid "Videos"
 msgstr ""
 
-#: inc/template-tags.php:177
+#: inc/template-tags.php:163
 msgctxt "post format archive title"
 msgid "Quotes"
 msgstr ""
 
-#: inc/template-tags.php:179
+#: inc/template-tags.php:165
 msgctxt "post format archive title"
 msgid "Links"
 msgstr ""
 
-#: inc/template-tags.php:181
+#: inc/template-tags.php:167
 msgctxt "post format archive title"
 msgid "Statuses"
 msgstr ""
 
-#: inc/template-tags.php:183
+#: inc/template-tags.php:169
 msgctxt "post format archive title"
 msgid "Audio"
 msgstr ""
 
-#: inc/template-tags.php:185
+#: inc/template-tags.php:171
 msgctxt "post format archive title"
 msgid "Chats"
 msgstr ""
 
-#: inc/template-tags.php:187
+#: inc/template-tags.php:173
 msgid "Archives: %s"
 msgstr ""
 
 #. translators: 1: Taxonomy singular name, 2: Current taxonomy term
 
-#: inc/template-tags.php:191
+#: inc/template-tags.php:177
 msgid "%1$s: %2$s"
 msgstr ""
 
-#: inc/template-tags.php:193
+#: inc/template-tags.php:179
 msgid "Archives"
 msgstr ""
 

--- a/sass/modules/_infinite-scroll.scss
+++ b/sass/modules/_infinite-scroll.scss
@@ -1,5 +1,5 @@
 /* Globally hidden elements when Infinite Scroll is supported and in use. */
-.infinite-scroll .paging-navigation, /* Older / Newer Posts Navigation (always hidden) */
+.infinite-scroll .posts-navigation, /* Older / Newer Posts Navigation (always hidden) */
 .infinite-scroll.neverending .site-footer { /* Theme Footer (when set to scrolling) */
 	display: none;
 }

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -78,21 +78,21 @@
 }
 
 .site-main .comment-navigation,
-.site-main .paging-navigation,
+.site-main .posts-navigation,
 .site-main .post-navigation {
 	margin: 0 0 1.5em;
 	overflow: hidden;
 }
 
 .comment-navigation .nav-previous,
-.paging-navigation .nav-previous,
+.posts-navigation .nav-previous,
 .post-navigation .nav-previous {
 	float: left;
 	width: 50%;
 }
 
 .comment-navigation .nav-next,
-.paging-navigation .nav-next,
+.posts-navigation .nav-next,
 .post-navigation .nav-next {
 	float: right;
 	text-align: right;

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -4,7 +4,7 @@ Theme URI: http://underscores.me/
 Author: Automattic
 Author URI: http://automattic.com/
 Description: Hi. I'm a starter theme called <code>_s</code>, or <em>underscores</em>, if you like. I'm a theme meant for hacking so don't use me as a <em>Parent Theme</em>. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.
-Version: 1.0-wpcom
+Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: _s
@@ -13,7 +13,7 @@ Tags:
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
- _s is based on Underscores http://underscores.me/, (C) 2012-2014 Automattic, Inc.
+_s is based on Underscores http://underscores.me/, (C) 2012-2015 Automattic, Inc.
 
 Resetting and rebuilding styles have been helped along thanks to the fine work of
 Eric Meyer http://meyerweb.com/eric/tools/css/reset/index.html

--- a/search.php
+++ b/search.php
@@ -30,7 +30,12 @@ get_header(); ?>
 
 			<?php endwhile; ?>
 
-			<?php _s_paging_nav(); ?>
+			<?php
+				the_posts_navigation( array(
+					'prev_text' => __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ),
+					'next_text' => __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ),
+				) );
+			?>
 
 		<?php else : ?>
 

--- a/search.php
+++ b/search.php
@@ -30,12 +30,7 @@ get_header(); ?>
 
 			<?php endwhile; ?>
 
-			<?php
-				the_posts_navigation( array(
-					'prev_text' => __( '<span class="meta-nav">&larr;</span> Older posts', '_s' ),
-					'next_text' => __( 'Newer posts <span class="meta-nav">&rarr;</span>', '_s' ),
-				) );
-			?>
+			<?php the_posts_navigation(); ?>
 
 		<?php else : ?>
 

--- a/single.php
+++ b/single.php
@@ -14,12 +14,7 @@ get_header(); ?>
 
 			<?php get_template_part( 'content', 'single' ); ?>
 
-			<?php
-				the_post_navigation( array(
-					'prev_text' => _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ),
-					'next_text' => _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ),
-				) );
-			?>
+			<?php the_post_navigation(); ?>
 
 			<?php
 				// If comments are open or we have at least one comment, load up the comment template

--- a/single.php
+++ b/single.php
@@ -14,7 +14,12 @@ get_header(); ?>
 
 			<?php get_template_part( 'content', 'single' ); ?>
 
-			<?php _s_post_nav(); ?>
+			<?php
+				the_post_navigation( array(
+					'prev_text' => _x( '<span class="meta-nav">&larr;</span>&nbsp;%title', 'Previous post link', '_s' ),
+					'next_text' => _x( '%title&nbsp;<span class="meta-nav">&rarr;</span>', 'Next post link',     '_s' ),
+				) );
+			?>
 
 			<?php
 				// If comments are open or we have at least one comment, load up the comment template

--- a/style.css
+++ b/style.css
@@ -506,21 +506,21 @@ a:active {
 }
 
 .site-main .comment-navigation,
-.site-main .paging-navigation,
+.site-main .posts-navigation,
 .site-main .post-navigation {
 	margin: 0 0 1.5em;
 	overflow: hidden;
 }
 
 .comment-navigation .nav-previous,
-.paging-navigation .nav-previous,
+.posts-navigation .nav-previous,
 .post-navigation .nav-previous {
 	float: left;
 	width: 50%;
 }
 
 .comment-navigation .nav-next,
-.paging-navigation .nav-next,
+.posts-navigation .nav-next,
 .post-navigation .nav-next {
 	float: right;
 	text-align: right;
@@ -685,7 +685,7 @@ a:active {
 11.0 Infinite scroll
 --------------------------------------------------------------*/
 /* Globally hidden elements when Infinite Scroll is supported and in use. */
-.infinite-scroll .paging-navigation, /* Older / Newer Posts Navigation (always hidden) */
+.infinite-scroll .posts-navigation, /* Older / Newer Posts Navigation (always hidden) */
 .infinite-scroll.neverending .site-footer { /* Theme Footer (when set to scrolling) */
 	display: none;
 }

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://underscores.me/
 Author: Automattic
 Author URI: http://automattic.com/
 Description: Hi. I'm a starter theme called <code>_s</code>, or <em>underscores</em>, if you like. I'm a theme meant for hacking so don't use me as a <em>Parent Theme</em>. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.
-Version: 1.0-wpcom
+Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: _s
@@ -13,7 +13,7 @@ Tags:
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
- _s is based on Underscores http://underscores.me/, (C) 2012-2014 Automattic, Inc.
+_s is based on Underscores http://underscores.me/, (C) 2012-2015 Automattic, Inc.
 
 Resetting and rebuilding styles have been helped along thanks to the fine work of
 Eric Meyer http://meyerweb.com/eric/tools/css/reset/index.html


### PR DESCRIPTION
Add the_posts_navigation() and the_post_navigation() in template-tags.php.
for WordPress 4.1+.

see. https://core.trac.wordpress.org/ticket/29808