### PR TITLE
Remove home link from wp_page_menu() args.

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -8,18 +8,6 @@
  */
 
 /**
- * Get our wp_nav_menu() fallback, wp_page_menu(), to show a home link.
- *
- * @param array $args Configuration arguments.
- * @return array
- */
-function _s_page_menu_args( $args ) {
-	$args['show_home'] = true;
-	return $args;
-}
-add_filter( 'wp_page_menu_args', '_s_page_menu_args' );
-
-/**
  * Adds custom classes to the array of body classes.
  *
  * @param array $classes Classes for the body element.


### PR DESCRIPTION
I think that we should remove the `_s_page_menu_args()` function that adds a Home link to page menus.

I don't think that I've ever added a Home link into a custom navigation menu, especially because it is a common pattern to link  the blog title or site logo to the homepage of a site. A quick search of the .org support forums seems to confirm this, as it shows a lot of requests from users on how to get rid of this particular link.

Additionally the hardcoded link is as confusing as hardcoded widgets, because it shows up with any user interaction.
