### PR TITLE
Reflect the change of color in the customizer.

### DIFF
--- a/js/customizer.js
+++ b/js/customizer.js
@@ -20,12 +20,12 @@
 	wp.customize( 'header_textcolor', function( value ) {
 		value.bind( function( to ) {
 			if ( 'blank' === to ) {
-				$( '.site-title, .site-description' ).css( {
+				$( '.site-title a, .site-description' ).css( {
 					'clip': 'rect(1px, 1px, 1px, 1px)',
 					'position': 'absolute'
 				} );
 			} else {
-				$( '.site-title, .site-description' ).css( {
+				$( '.site-title a, .site-description' ).css( {
 					'clip': 'auto',
 					'color': to,
 					'position': 'relative'


### PR DESCRIPTION
Reflect the change of color of the title in the customizer.
Fixed ".site-title" to ".site-title a".

If you change the header text color in the customizer, it will not be reflected immediately.
By changing the ".site-title" of customizer.js to ".site-title a", the header text color will now be reflected immediately.