### PR TITLE
Remove unnecessary margin-top and margin-bottom from center-block mixin.

### DIFF
--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -7,7 +7,8 @@
 // Center block
 @mixin center-block {
 	display: block;
-	margin: 0 auto;
+	margin-left: auto;
+	margin-right: auto;
 }
 
 // Clearfix

--- a/style.css
+++ b/style.css
@@ -579,7 +579,8 @@ a:active {
 .aligncenter {
 	clear: both;
 	display: block;
-	margin: 0 auto;
+	margin-left: auto;
+	margin-right: auto;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
Setting top and bottom margins is not necessary to center the element, and it can potentially override the margins set by another rule.