### PR TITLE
Set a fixed table-layout in the clearfix to avoid max-width conflict

### DIFF
--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -14,6 +14,7 @@
 @mixin clearfix() {
 	content: "";
 	display: table;
+	table-layout: fixed;
 }
 
 // Clear after (not all clearfix need this also)

--- a/style.css
+++ b/style.css
@@ -599,6 +599,7 @@ a:active {
 .site-footer:after {
 	content: "";
 	display: table;
+	table-layout: fixed;
 }
 
 .clear:after,


### PR DESCRIPTION
I'm not sure if this is a problem or not, but I figured I'd open a discussion to document it and see what other people think.

Setting `display: table` in the clearfix can lead to some browsers ignoring the max-width property on child elements (see links at the bottom). I've created [a minimal example](https://iandunn.name/content/misc/2015/_s-clearfix-max-width.html), so you can see the issue by opening it in the Firefox 34 or IE 11.

I'm hesitent to say this is an actual issue, since the CSSMojo clearfix is pretty popular and I wasn't able to find any other discussions about the conflict with it specifically, but at least in my limited experience, it seems like it's a problem.

So far, adding `table-layout: fixed` to the `clearfix` mixin solves the problem for me with no side-effects.

### References
* http://www.carsonshold.com/2014/07/css-display-table-cell-child-width-bug-in-firefox-and-ie/
* http://stackoverflow.com/a/11310261/450127
* https://bugzilla.mozilla.org/show_bug.cgi?id=975632