### PR TITLE
Lay out content and widget areas with inline-block instead of floats.

### DIFF
--- a/layouts/content-sidebar.css
+++ b/layouts/content-sidebar.css
@@ -5,7 +5,7 @@ Layout: Content-Sidebar
 
 .content-area {
 	display: inline-block;
-	margin: 0 -25% 0 -6px;
+	margin: 0 -25% 0 -6px;	/* left margin offsets the inline-block spacing, see http://css-tricks.com/fighting-the-space-between-inline-block-elements/ */
 	padding-left: 6px;
 	width: 100%;
 }

--- a/layouts/content-sidebar.css
+++ b/layouts/content-sidebar.css
@@ -4,15 +4,16 @@ Layout: Content-Sidebar
 */
 
 .content-area {
-	float: left;
-	margin: 0 -25% 0 0;
+	display: inline-block;
+	margin: 0 -25% 0 -6px;
+	padding-left: 6px;
 	width: 100%;
 }
 .site-main {
 	margin: 0 25% 0 0;
 }
 .site-content .widget-area {
-	float: right;
+	display: inline-block;
 	overflow: hidden;
 	width: 25%;
 }

--- a/layouts/sidebar-content.css
+++ b/layouts/sidebar-content.css
@@ -3,18 +3,26 @@ Theme Name: _s
 Layout: Sidebar-Content
 */
 
+.site-content {
+	direction: rtl; /* Swap the positioning of .content-area and .widget-area without affecting the source order */
+}
+
 .content-area {
-	float: right;
+	display: inline-block;
 	margin: 0 0 0 -25%;
 	width: 100%;
+	direction: ltr;
 }
 .site-main {
 	margin: 0 0 0 25%;
 }
 .site-content .widget-area {
-	float: left;
+	display: inline-block;
+	margin-left: -6px;
+	padding-left: 6px;
 	overflow: hidden;
 	width: 25%;
+	direction: ltr;
 }
 .site-footer {
 	clear: both;

--- a/layouts/sidebar-content.css
+++ b/layouts/sidebar-content.css
@@ -18,7 +18,7 @@ Layout: Sidebar-Content
 }
 .site-content .widget-area {
 	display: inline-block;
-	margin-left: -6px;
+	margin-left: -6px;	/* offset the inline-block spacing, see http://css-tricks.com/fighting-the-space-between-inline-block-elements/ */
 	padding-left: 6px;
 	overflow: hidden;
 	width: 25%;

--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -4,8 +4,9 @@ html {
 
 *,
 *:before,
-*:after { /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
-	box-sizing: inherit;
+*:after {
+	box-sizing: inherit; /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
+	vertical-align: top;
 }
 
 body {

--- a/sass/layout/_content-sidebar.scss
+++ b/sass/layout/_content-sidebar.scss
@@ -1,6 +1,7 @@
 .content-area {
-	float: left;
-	margin: 0 (-$size__site-sidebar) 0 0;
+	display: inline-block;
+	margin: 0 (-$size__site-sidebar) 0 $margin__offset-inline-block-spacing;
+	padding-left: $margin__offset-inline-block-spacing * -1;
 	width: $size__site-main;
 }
 
@@ -9,7 +10,7 @@
 }
 
 .site-content .widget-area {
-	float: right;
+	display: inline-block;
 	overflow: hidden;
 	width: $size__site-sidebar;
 }

--- a/sass/layout/_sidebar-content.scss
+++ b/sass/layout/_sidebar-content.scss
@@ -1,7 +1,12 @@
+.site-content {
+	direction: rtl; /* Swap the positioning of .content-area and .widget-area without affecting the source order */
+}
+
 .content-area {
-	float: right;
+	display: inline-block;
 	margin: 0 0 0 (-$size__site-sidebar);
 	width: $size__site-main;
+	direction: ltr;
 }
 
 .site-main {
@@ -9,9 +14,12 @@
 }
 
 .site-content .widget-area {
-	float: left;
+	display: inline-block;
+	margin-left: $margin__offset-inline-block-spacing;
+	padding-left: $margin__offset-inline-block-spacing * -1;
 	overflow: hidden;
 	width: $size__site-sidebar;
+	direction: ltr;
 }
 
 .site-footer {

--- a/sass/modules/_clearings.scss
+++ b/sass/modules/_clearings.scss
@@ -6,8 +6,6 @@
 .comment-content:after,
 .site-header:before,
 .site-header:after,
-.site-content:before,
-.site-content:after,
 .site-footer:before,
 .site-footer:after {
 	@include clearfix;
@@ -17,7 +15,6 @@
 .entry-content:after,
 .comment-content:after,
 .site-header:after,
-.site-content:after,
 .site-footer:after {
 	@include clearfix-after;
 }

--- a/sass/variables-site/_structure.scss
+++ b/sass/variables-site/_structure.scss
@@ -1,3 +1,3 @@
 $size__site-main: 100%;
 $size__site-sidebar: 25%;
-$margin__offset-inline-block-spacing: -6px;
+$margin__offset-inline-block-spacing: -6px;	/* http://css-tricks.com/fighting-the-space-between-inline-block-elements/ */

--- a/sass/variables-site/_structure.scss
+++ b/sass/variables-site/_structure.scss
@@ -1,2 +1,3 @@
 $size__site-main: 100%;
 $size__site-sidebar: 25%;
+$margin__offset-inline-block-spacing: -6px;

--- a/style.css
+++ b/style.css
@@ -359,8 +359,9 @@ html {
 
 *,
 *:before,
-*:after { /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
-	box-sizing: inherit;
+*:after {
+	box-sizing: inherit;  /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
+	vertical-align: top;
 }
 
 body {
@@ -700,8 +701,6 @@ a:active {
 .comment-content:after,
 .site-header:before,
 .site-header:after,
-.site-content:before,
-.site-content:after,
 .site-footer:before,
 .site-footer:after {
 	content: "";
@@ -712,7 +711,6 @@ a:active {
 .entry-content:after,
 .comment-content:after,
 .site-header:after,
-.site-content:after,
 .site-footer:after {
 	clear: both;
 }


### PR DESCRIPTION
This is the current best practice, and it avoids the need for the clearfix hack because inline-block elements aren't pulled out of the document flow.