### PR TITLE
Separating registration and enqueuing of scripts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -100,11 +100,16 @@ add_action( 'widgets_init', '_s_widgets_init' );
  * Enqueue scripts and styles.
  */
 function _s_scripts() {
+	
+	wp_register_script('_s-navigation'), get_template_directory_uri() . '/js/navigation.js', array(), '20120206', true );
+	
+	wp_register_script('_s-skip-link-focus-fix'), get_template_directory_uri() . '/js/navigation.js', array(), '20120206', true );
+	
 	wp_enqueue_style( '_s-style', get_stylesheet_uri() );
 
-	wp_enqueue_script( '_s-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20120206', true );
+	wp_enqueue_script( '_s-navigation' );
 
-	wp_enqueue_script( '_s-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20130115', true );
+	wp_enqueue_script( '_s-skip-link-focus-fix' );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );


### PR DESCRIPTION
I know it's not a requirement, but it does seem like a cleaner way to do this, particularly as developers will be enqueuing more scripts and styles, generally speaking.