### PR TITLE
Improve translation string of _s_posted_on()

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -83,16 +83,16 @@ function _s_posted_on() {
 	);
 
 	$posted_on = sprintf(
-		_x( 'Posted on %s', 'post date', '_s' ),
-		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
+		'<span class="posted-on"><a href="%1$s" rel="bookmark">%2$s</a></span>',
+		esc_url( get_permalink() ), $time_string
 	);
 
 	$byline = sprintf(
-		_x( 'by %s', 'post author', '_s' ),
-		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+		'<span class="byline"><a class="url fn n" href="%1$s">%2$s</a></span>',
+		esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ), esc_html( get_the_author() )
 	);
 
-	echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>';
+	printf( _x( 'Posted on %1$s by %2$s', 'author date', '_s' ), $posted_on, $byline );
 
 }
 endif;

--- a/languages/_s.pot
+++ b/languages/_s.pot
@@ -127,14 +127,9 @@ msgstr ""
 msgid "Post navigation"
 msgstr ""
 
-#: inc/template-tags.php:86
-msgctxt "post date"
-msgid "Posted on %s"
-msgstr ""
-
-#: inc/template-tags.php:91
-msgctxt "post author"
-msgid "by %s"
+#: inc/template-tags.php:95
+msgctxt "author date"
+msgid "Posted on %1$s by %2$s"
 msgstr ""
 
 #. translators: used between list items, there is a space after the comma


### PR DESCRIPTION
The output of _s_posted_on() function is split in 2 translation strings with no possibility to interchange them. Currently the output is locked to "Posted on {date} by {author}". Combining them into a single translation string allows for output like "Posted by {author} on {date}" or even "{author} wrote this on {date}" and it even improves the translation possibilities for languages with non-latin semantics.

I know that I have made some dramatic changes to established translation strings, but also adding HTML tags to translation strings isn't the most elegant solution and this pull request doesn't need to be merged as is. I propose a discussion wether prepositions like "on" and "by" actually make a semantic sense when wrapped in <span> tags together with the meta and wether the word "Posted" is directly related to the post date or makes sense even outside this context.