### PR TITLE
Minor SASS Syntax corrections

### DIFF
--- a/sass/_normalize.scss
+++ b/sass/_normalize.scss
@@ -43,11 +43,11 @@ template {
 
 a {
 	background-color: transparent;
-}
 
-a:active,
-a:hover {
-	outline: 0;
+	&:active,
+	&:hover {
+		outline: 0;
+	}
 }
 
 abbr[title] {
@@ -178,11 +178,11 @@ input[type="number"]::-webkit-outer-spin-button {
 input[type="search"] {
 	-webkit-appearance: textfield;
 	box-sizing: content-box;
-}
 
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-	-webkit-appearance: none;
+	&::-webkit-search-cancel-button,
+	&::-webkit-search-decoration {
+		-webkit-appearance: none;
+	}
 }
 
 fieldset {

--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -12,13 +12,13 @@ body {
 	background: $color__background-body; /* Fallback for when there is no custom background color defined. */
 }
 
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: "";
-}
-
 blockquote, q {
 	quotes: "" "";
+
+	&:before,
+	&:after {
+		content: "";
+	}
 }
 
 hr {

--- a/sass/elements/_lists.scss
+++ b/sass/elements/_lists.scss
@@ -1,4 +1,5 @@
-ul, ol {
+ul,
+ol {
 	margin: 0 0 1.5em 3em;
 }
 

--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -12,24 +12,15 @@ input[type="submit"] {
 	line-height: 1;
 	padding: .6em 1em .4em;
 	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
-}
 
-button:hover,
-input[type="button"]:hover,
-input[type="reset"]:hover,
-input[type="submit"]:hover {
-	border-color: $color__border-button-hover;
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 15px 17px rgba(255, 255, 255, 0.8), inset 0 -5px 12px rgba(0, 0, 0, 0.02);
-}
+	&:hover {
+		border-color: $color__border-button-hover;
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 15px 17px rgba(255, 255, 255, 0.8), inset 0 -5px 12px rgba(0, 0, 0, 0.02);
+	}
 
-button:focus,
-input[type="button"]:focus,
-input[type="reset"]:focus,
-input[type="submit"]:focus,
-button:active,
-input[type="button"]:active,
-input[type="reset"]:active,
-input[type="submit"]:active {
-	border-color: $color__border-button-focus;
-	box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.15);
+	&:focus,
+	&:active {
+		border-color: $color__border-button-focus;
+		box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.15);
+	}
 }

--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -7,15 +7,10 @@ textarea {
 	color: $color__text-input;
 	border: 1px solid $color__border-input;
 	border-radius: 3px;
-}
 
-input[type="text"]:focus,
-input[type="email"]:focus,
-input[type="url"]:focus,
-input[type="password"]:focus,
-input[type="search"]:focus,
-textarea:focus {
-	color: $color__text-input-focus;
+	&:focus {
+		color: $color__text-input-focus;
+	}
 }
 
 input[type="text"],

--- a/sass/media/_galleries.scss
+++ b/sass/media/_galleries.scss
@@ -7,38 +7,38 @@
 	text-align: center;
 	vertical-align: top;
 	width: 100%;
-}
 
-.gallery-columns-2 .gallery-item {
-	max-width: 50%;
-}
+	.gallery-columns-2 & {
+		max-width: 50%;
+	}
 
-.gallery-columns-3 .gallery-item {
-	max-width: 33.33%;
-}
+	.gallery-columns-3 & {
+		max-width: 33.33%;
+	}
 
-.gallery-columns-4 .gallery-item {
-	max-width: 25%;
-}
+	.gallery-columns-4 & {
+		max-width: 25%;
+	}
 
-.gallery-columns-5 .gallery-item {
-	max-width: 20%;
-}
+	.gallery-columns-5 & {
+		max-width: 20%;
+	}
 
-.gallery-columns-6 .gallery-item {
-	max-width: 16.66%;
-}
+	.gallery-columns-6 & {
+		max-width: 16.66%;
+	}
 
-.gallery-columns-7 .gallery-item {
-	max-width: 14.28%;
-}
+	.gallery-columns-7 & {
+		max-width: 14.28%;
+	}
 
-.gallery-columns-8 .gallery-item {
-	max-width: 12.5%;
-}
+	.gallery-columns-8 & {
+		max-width: 12.5%;
+	}
 
-.gallery-columns-9 .gallery-item {
-	max-width: 11.11%;
+	.gallery-columns-9 & {
+		max-width: 11.11%;
+	}
 }
 
 .gallery-caption {

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -77,24 +77,22 @@
 	}
 }
 
-.site-main .comment-navigation,
-.site-main .posts-navigation,
-.site-main .post-navigation {
-	margin: 0 0 1.5em;
-	overflow: hidden;
-}
+.comment-navigation,
+.posts-navigation,
+.post-navigation {
+	.site-main & {
+		margin: 0 0 1.5em;
+		overflow: hidden;
+	}
 
-.comment-navigation .nav-previous,
-.posts-navigation .nav-previous,
-.post-navigation .nav-previous {
-	float: left;
-	width: 50%;
-}
+	& .nav-previous {
+		float: left;
+		width: 50%;
+	}
 
-.comment-navigation .nav-next,
-.posts-navigation .nav-next,
-.post-navigation .nav-next {
-	float: right;
-	text-align: right;
-	width: 50%;
+	& .nav-next {
+		float: right;
+		text-align: right;
+		width: 50%;
+	}
 }

--- a/sass/typography/_copy.scss
+++ b/sass/typography/_copy.scss
@@ -2,11 +2,9 @@ p {
 	margin-bottom: 1.5em;
 }
 
-b, strong {
-	font-weight: bold;
-}
-
-dfn, cite, em, i {
+cite,
+em,
+i {
 	font-style: italic;
 }
 
@@ -29,17 +27,22 @@ pre {
 	padding: 1.6em;
 }
 
-code, kbd, tt, var {
+code,
+kbd,
+tt,
+var {
 	font-family: $font__code;
 	@include font-size(0.9375);
 }
 
-abbr, acronym {
+abbr,
+acronym {
 	border-bottom: 1px dotted $color__border-abbr;
 	cursor: help;
 }
 
-mark, ins {
+mark,
+ins {
 	background: $color__background-ins;
 	text-decoration: none;
 }

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -1,3 +1,8 @@
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
 	clear: both;
 }


### PR DESCRIPTION
Found a few places where the SASS syntax could be corrected and shortened on several files. I also found some styles that were duplicates after _s moved to Normalize. I also noticed in the WP CSS Code Standards the other day that each CSS property should be on its own line, so I fixed those as well. These are all super minor - and none of these changes alter the style.css, just the SASS files.