### PR TITLE
Sanitize location.hash before passing it to getElementById

### DIFF
--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -5,7 +5,14 @@
 
 	if ( ( is_webkit || is_opera || is_ie ) && document.getElementById && window.addEventListener ) {
 		window.addEventListener( 'hashchange', function() {
-			var element = document.getElementById( location.hash.substring( 1 ) );
+			var id = location.hash.substring( 1 ),
+				element;
+
+			if ( ! /^[A-z0-9_-]+$/.test( id ) ) {
+				return;
+			}
+
+			element = document.getElementById( id );
 
 			if ( element ) {
 				if ( ! /^(?:a|select|input|button|textarea)$/i.test( element.tagName ) ) {


### PR DESCRIPTION
There is no actual vulnerability in the existing implementation, as we can only fetch existing elements (no DOM injection is possible). Plus, the only call occurring on those elements is `HTMLElement#focus`.

Consider this an extra, more future-proof precaution.

Fixes #701