### PR TITLE
remove redundant link :hover and :active style, shift a:focus to reset

### DIFF
--- a/sass/navigation/_links.scss
+++ b/sass/navigation/_links.scss
@@ -9,11 +9,7 @@ a {
 	&:active {
 		color: $color__link-hover;
 	}
-	&:focus {
+	&:focus { /* the :focus state is important for keyboard accessibility: http://24ways.org/2009/dont-lose-your-focus/ */
 		outline: thin dotted;
-	}
-	&:hover,
-	&:active {
-		outline: 0;
 	}
 }

--- a/style.css
+++ b/style.css
@@ -507,13 +507,8 @@ a:active {
 	color: midnightblue;
 }
 
-a:focus {
+a:focus { /* a :focus state is crucial for keyboard accessibility: http://24ways.org/2009/dont-lose-your-focus/ */
 	outline: thin dotted;
-}
-
-a:hover,
-a:active {
-	outline: 0;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
Right now, [lines 514-517 of style.css](https://github.com/Automattic/_s/blob/70b8baf2ed1a3b965aa163204df45bec8208ae1d/style.css#L514) are identical to [lines 96-99](https://github.com/Automattic/_s/blob/70b8baf2ed1a3b965aa163204df45bec8208ae1d/style.css#L96) (except for order of the two selectors).

This PR removes the second instance, deeming the style more "normalize" than "link." As part of this move, I also shifted the now-"orphaned" `a:focus` style that accompanied the second instance to the be next to the first instance of the redundant style so all normalizing link stuff is in one place.

From an accessibility perspective, I think this is better too as the remaining link styles should be edited with ease (they're just colors) but the :focus style requires a bit more care and must not just be removed.