### PR TITLE
Fix for <div id="content class="site-content">

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -8,15 +8,13 @@
  */
 ?>
 
-	</div><!-- #content -->
-
-	<footer id="colophon" class="site-footer" role="contentinfo">
-		<div class="site-info">
-			<a href="<?php echo esc_url( __( 'http://wordpress.org/', '_s' ) ); ?>"><?php printf( __( 'Proudly powered by %s', '_s' ), 'WordPress' ); ?></a>
-			<span class="sep"> | </span>
-			<?php printf( __( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="http://automattic.com/" rel="designer">Automattic</a>' ); ?>
-		</div><!-- .site-info -->
-	</footer><!-- #colophon -->
+  <footer id="colophon" class="site-footer" role="contentinfo">
+    <div class="site-info">
+      <a href="<?php echo esc_url( __( 'http://wordpress.org/', '_s' ) ); ?>"><?php printf( __( 'Proudly powered by %s', '_s' ), 'WordPress' ); ?></a>
+      <span class="sep"> | </span>
+      <?php printf( __( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="http://automattic.com/" rel="designer">Automattic</a>' ); ?>
+    </div><!-- .site-info -->
+  </footer><!-- #colophon -->
 </div><!-- #page -->
 
 <?php wp_footer(); ?>

--- a/header.php
+++ b/header.php
@@ -32,5 +32,3 @@
 			<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu' ) ); ?>
 		</nav><!-- #site-navigation -->
 	</header><!-- #masthead -->
-
-	<div id="content" class="site-content">


### PR DESCRIPTION
When html validating a recent site built on _s I noticed that there are two elements with duplicate classes and id's. There is a `<div>` in header.php with an id of "content" and class of "site-content". These show up again on the `<main>` element in both the single.php and page.php templates. It seemed to make sense to remove the `<div>` element. It seems to make more sense from a semantic point of view to have the id of content on the `<main>` element. I am a first time contributor to this repo so please forgive my ignorance if I am missing something.