### PR TITLE
State licence of Underscores

### DIFF
--- a/sass/style.scss
+++ b/sass/style.scss
@@ -14,6 +14,7 @@ This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
 _s is based on Underscores http://underscores.me/, (C) 2012-2015 Automattic, Inc.
+Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal http://necolas.github.com/normalize.css/

--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@ This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
 _s is based on Underscores http://underscores.me/, (C) 2012-2015 Automattic, Inc.
+Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal http://necolas.github.com/normalize.css/


### PR DESCRIPTION
When generating a theme there is no mention what license Underscores is released under. The PR is based on the advice from Chip in the post "[Proper Copyright/License Attribution for Themes](https://make.wordpress.org/themes/2014/07/08/proper-copyrightlicense-attribution-for-themes/)"