### PR TITLE
added menu navigation with arrow keys

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -78,4 +78,60 @@
 			self = self.parentElement;
 		}
 	}
+
+	// menu navigation with arrow keys
+
+	var mainMenus = document.getElementsByClassName('menu');
+	var subMenus = document.getElementsByClassName('sub-menu');
+
+	var combinedMenus = [].concat(Array.prototype.slice.call(mainMenus), Array.prototype.slice.call(subMenus));
+	var cMenusLen = combinedMenus.length;
+
+	for(var m = 0; m < cMenusLen; m++) {
+		var allMenuLis = combinedMenus[m].children;
+		lisLen = allMenuLis.length;
+
+		for (var l = 0; l < lisLen; l++) {
+			allMenuLis.item(l).firstElementChild.addEventListener('keydown', function(e){
+				var key = e.which || e.keyCode;
+
+				// left key
+				if(key === 37) {
+					e.preventDefault();
+					if(this.parentElement.previousElementSibling) {
+						this.parentElement.previousElementSibling.firstElementChild.focus();
+					}
+				}
+				// right key
+				else if(key === 39) {
+					e.preventDefault();
+					if(this.parentElement.nextElementSibling) {
+						this.parentElement.nextElementSibling.firstElementChild.focus();
+					}
+				}
+				// down key
+				else if(key === 40) {
+					e.preventDefault();
+					if(this.nextElementSibling){
+						this.nextElementSibling.firstElementChild.firstElementChild.focus();
+					}
+					else if (this.parentElement.nextElementSibling) {
+						this.parentElement.nextElementSibling.firstElementChild.focus();
+					}
+				}
+				// up key
+				else if(key === 38) {
+					e.preventDefault();
+					if(this.parentElement.previousElementSibling){
+						this.parentElement.previousElementSibling.firstElementChild.focus();
+					}
+					else if (this.parentElement.parentElement.previousElementSibling){
+						this.parentElement.parentElement.previousElementSibling.focus();
+					}
+				}
+
+			}); //end add event listener
+		}
+	}
+
 } )();


### PR DESCRIPTION
Added a bit of code to navigation.js to enable keyboard navigation with the arrow keys on menus (not just the main navigation menu, but also any extra menus there may be - widget menus, etc.). This is useful for large menus with sub-menus as it enables navigation of top items without having to go through all sub-items. 