### PR TITLE
Option to remove margins from Admin Toolbar

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -70,7 +70,7 @@ function _s_setup() {
 	) );
 	
 	/*
-	 * Remove margin from HTML/Body added by Admin Bar
+	 * Remove margin from HTML/BODY added by Admin Bar
 	 * Useful if absolute positioning used in header area
 	 */
 	 /*

--- a/functions.php
+++ b/functions.php
@@ -68,6 +68,16 @@ function _s_setup() {
 	add_theme_support( 'post-formats', array(
 		'aside', 'image', 'video', 'quote', 'link',
 	) );
+	
+	/*
+	 * Remove margin from HTML/Body added by Admin Bar
+	 * Useful if absolute positioning used in header area
+	 */
+	 /*
+	 add_theme_support( 'admin-bar', array(
+		'callback' => '__return_false'
+	) );
+	*/
 
 	// Set up the WordPress core custom background feature.
 	add_theme_support( 'custom-background', apply_filters( '_s_custom_background_args', array(


### PR DESCRIPTION
Code that can be uncommented to remove margins added by the Admin Toolbar.

Useful for if a website has elements at the top of the page that use absolute positioning, as the toolbar can push things out of alignment or create white space.

Could be useful to some.