### PR TITLE
Add a readme.txt file

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,27 @@
+=== _s ===
+Contributors: automattic
+Tags: featured-images, translation-ready, custom-background, theme-options
+Requires at least: 4.0
+Tested up to: 4.2
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Short description. No more than 150 chars.
+
+== Description ==
+Full theme description.
+
+== Frequently Asked Questions ==
+
+= A question that someone might have =
+
+An answer to that question.
+
+== Changelog ==
+
+= 1.0 =
+* Initial release
+
+== Resources ==
+ * example-script.js © 2015 Jane Doe, CC0

--- a/readme.txt
+++ b/readme.txt
@@ -1,27 +1,30 @@
 === _s ===
 Contributors: automattic
-Tags: featured-images, translation-ready, custom-background, theme-options
+Tags: translation-ready, custom-background, theme-options, custom-menu, post-formats, threaded-comments
 Requires at least: 4.0
 Tested up to: 4.2
 Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Short description. No more than 150 chars.
+A starter theme called _s, or underscores.
 
 == Description ==
-Full theme description.
+
+Hi. I'm a starter theme called _s, or underscores, if you like. I'm a theme meant for hacking so don't use me as a Parent Theme. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.
 
 == Frequently Asked Questions ==
 
-= A question that someone might have =
+= Does this theme support any plugins? =
 
-An answer to that question.
+_s includes support for Infinite Scroll in Jetpack.
 
 == Changelog ==
 
 = 1.0 =
 * Initial release
 
-== Resources ==
- * example-script.js © 2015 Jane Doe, CC0
+== Credits ==
+
+* Based on Underscores http://underscores.me/, (C) 2012-2015 Automattic, Inc., MIT
+* normalize.css http://necolas.github.io/normalize.css/, (C) 2012-2015 Nicolas Gallagher and Jonathan Neal, MIT

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,10 @@
 === _s ===
+
 Contributors: automattic
 Tags: translation-ready, custom-background, theme-options, custom-menu, post-formats, threaded-comments
+
 Requires at least: 4.0
-Tested up to: 4.2
+Tested up to: 4.2.2
 Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -13,6 +15,12 @@ A starter theme called _s, or underscores.
 
 Hi. I'm a starter theme called _s, or underscores, if you like. I'm a theme meant for hacking so don't use me as a Parent Theme. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.
 
+== Installation ==
+	
+1. In your admin panel, go to Appearance > Themes and click the Add New button.
+2. Click Upload and Choose File, then select the theme's .zip file. Click Install Now.
+3. Click Activate to use your new theme right away.
+
 == Frequently Asked Questions ==
 
 = Does this theme support any plugins? =
@@ -21,10 +29,10 @@ _s includes support for Infinite Scroll in Jetpack.
 
 == Changelog ==
 
-= 1.0 =
+= 1.0 - May 12 2015 =
 * Initial release
 
 == Credits ==
 
-* Based on Underscores http://underscores.me/, (C) 2012-2015 Automattic, Inc., MIT
-* normalize.css http://necolas.github.io/normalize.css/, (C) 2012-2015 Nicolas Gallagher and Jonathan Neal, MIT
+* Based on Underscores http://underscores.me/, (C) 2012-2015 Automattic, Inc., [GPL2](https://www.gnu.org/licenses/gpl-2.0.html)
+* normalize.css http://necolas.github.io/normalize.css/, (C) 2012-2015 Nicolas Gallagher and Jonathan Neal, [MIT](http://opensource.org/licenses/MIT)


### PR DESCRIPTION
This is based on the recommendation of the theme review team.

https://make.wordpress.org/themes/2015/04/29/a-revised-readme/

The goal is for a uniformly structured readme file adopted by all theme authors. Having the template ready in _s would speed up the adoption.