### PR TITLE
Remove :hover and :active states on screen-reader-text

### DIFF
--- a/style.css
+++ b/style.css
@@ -642,8 +642,6 @@ a:active {
 	overflow: hidden;
 }
 
-.screen-reader-text:hover,
-.screen-reader-text:active,
 .screen-reader-text:focus {
 	background-color: #f1f1f1;
 	border-radius: 3px;


### PR DESCRIPTION
We should consider removing all CSS rules that provide `:hover` and `:active` pseudo element behavior for `screen-reader-text` elements.

In IE 10/11, the `screen-reader-text` element, normally hidden, pops up when you hover your mouse over it, obscuring content — the Archives Widget drop-down menu is a good example.

According to the latest from the core a11y team: ​https://make.wordpress.org/accessibility/2015/02/09/hiding-text-for-screen-readers-with-wordpress-core/ -- we only need the `:focus` pseudo element class.

Props to @lancewillett for figuring this out.