### PR TITLE
Added optional bootstrap and font awesome includes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -111,6 +111,14 @@ function _s_scripts() {
 
 	wp_enqueue_script( '_s-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20130115', true );
 
+	//uncomment the 2 lines below to use bootstrap minified via cdn
+	//wp_enqueue_style( '_s-bootstrap', '//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css' );
+	
+	//wp_enqueue_script( '_s-bootstrap_js', '//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js', array('jquery'), '', true );
+	
+	//uncomment to use fontawesome minified css via cdn
+	//wp_enqueue_style( '_s-font-awesome', '//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css' );
+	
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );
 	}


### PR DESCRIPTION
A lot of us know that bootstrap is bad for wordpress based from this article
http://themeshaper.com/2014/08/19/why-bootstrap-is-a-bad-fit-for-wordpress-themes/

But there are still a lot of front end developers that loves to use underscores and bootstrap because it gives us the ability to write shorter code in implementing responsive sites by familiarizing the bootstrap grid system and has greatly increased our responsive implementation by more than two folds.

Hopefully we can include this as an optional enqueue script in benefit for all of those that loves underscores and bootstrap folks out there.

Thanks for sharing us underscores! more power to all of you guys!