### PR TITLE
Updated Tagline markup as per W3C guidelines.

### DIFF
--- a/header.php
+++ b/header.php
@@ -25,7 +25,7 @@
 	<header id="masthead" class="site-header" role="banner">
 		<div class="site-branding">
 			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-			<h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
+			<p class="site-description"><?php bloginfo( 'description' ); ?></p>
 		</div><!-- .site-branding -->
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">


### PR DESCRIPTION
W3C has this to say:

>h1–h6 elements must not be used to markup subheadings, subtitles, alternative titles and taglines unless intended to be the heading for a new section or subsection.

<a href="http://www.w3.org/html/wg/drafts/html/master/sections.html#headings-and-sections">W3C</a>

The reason for this is that the HTML5 document outline always interprets a heading tag as beginning a new section of content, whether sectioning content tags are wrapped around them or not.

For a while there was a work-around to this whereby `<h2>` tags could be used for a tagline if they were grouped with the main heading inside a set of `<hgroup>` tags. However, the `<hgroup>` is being removed from the HTML5 spec and its use will cause code to fail validation checks.

So now the best way to handle taglines is just to use `<div>` or `<p>` tags and apply CSS to make them look like taglines, achieving your presentation goal without negatively affecting your document outline.

You can refer this [article](http://webdesign.tutsplus.com/articles/the-truth-about-multiple-h1-tags-in-the-html5-era--webdesign-16824).