### PR TITLE
Minor link update for languages

### DIFF
--- a/languages/readme.txt
+++ b/languages/readme.txt
@@ -2,6 +2,6 @@ Place your theme language files in this directory.
 
 Please visit the following links to learn more about translating WordPress themes:
 
-http://codex.wordpress.org/WordPress_in_Your_Language
+https://make.wordpress.org/polyglots/teams/
 https://developer.wordpress.org/themes/functionality/localization/
-http://codex.wordpress.org/Function_Reference/load_theme_textdomain
+https://developer.wordpress.org/reference/functions/load_theme_textdomain/


### PR DESCRIPTION
- http://codex.wordpress.org/WordPress_in_Your_Language now redirects to https://make.wordpress.org/polyglots/teams/
- http://codex.wordpress.org/Function_Reference/load_theme_textdomain has new (nicer) home https://developer.wordpress.org/reference/functions/load_theme_textdomain/