### PR TITLE
Add post title to `edit_post_link`

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -123,7 +123,14 @@ function _s_entry_footer() {
 		echo '</span>';
 	}
 
-	edit_post_link( esc_html__( 'Edit', '_s' ), '<span class="edit-link">', '</span>' );
+	edit_post_link(
+		sprintf(
+			esc_html_x( 'Edit %s', 'name of current post', '_s' ),
+			wp_kses( the_title( '<span class="screen-reader-text">"', '"</span>', false ), array( 'span' => array( 'class' => array() ) ) )
+		),
+		'<span class="edit-link">',
+		'</span>'
+	);
 }
 endif;
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -125,8 +125,9 @@ function _s_entry_footer() {
 
 	edit_post_link(
 		sprintf(
-			esc_html_x( 'Edit %s', 'name of current post', '_s' ),
-			wp_kses( the_title( '<span class="screen-reader-text">"', '"</span>', false ), array( 'span' => array( 'class' => array() ) ) )
+			/* translators: %s: Name of current post */
+			esc_html__( 'Edit %s', '_s' ),
+			the_title( '<span class="screen-reader-text">"', '"</span>', false )
 		),
 		'<span class="edit-link">',
 		'</span>'

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -26,8 +26,9 @@
 		<?php
 			edit_post_link(
 				sprintf(
-					esc_html_x( 'Edit %s', 'name of current post', '_s' ),
-					wp_kses( the_title( '<span class="screen-reader-text">"', '"</span>', false ), array( 'span' => array( 'class' => array() ) ) )
+					/* translators: %s: Name of current post */
+					esc_html__( 'Edit %s', '_s' ),
+					the_title( '<span class="screen-reader-text">"', '"</span>', false )
 				),
 				'<span class="edit-link">',
 				'</span>'

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -23,7 +23,16 @@
 	</div><!-- .entry-content -->
 
 	<footer class="entry-footer">
-		<?php edit_post_link( esc_html__( 'Edit', '_s' ), '<span class="edit-link">', '</span>' ); ?>
+		<?php
+			edit_post_link(
+				sprintf(
+					esc_html_x( 'Edit %s', 'name of current post', '_s' ),
+					wp_kses( the_title( '<span class="screen-reader-text">"', '"</span>', false ), array( 'span' => array( 'class' => array() ) ) )
+				),
+				'<span class="edit-link">',
+				'</span>'
+			);
+		?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-## -->
 


### PR DESCRIPTION
This improves the accessibility of these links, and gives more context for screen reader users. Now, they know exactly where the link goes.

Escaped output with `esc_html_x` and `wp_kses`.

Resolves: #774