### PR TITLE
Add style.css missing main font family

### DIFF
--- a/style.css
+++ b/style.css
@@ -272,6 +272,7 @@ input,
 select,
 textarea {
 	color: #404040;
+	font-family: sans-serif;
 	font-size: 16px;
 	font-size: 1rem;
 	line-height: 1.5;


### PR DESCRIPTION
Hello,

I believe the [main font family](https://github.com/Automattic/_s/blob/master/sass/typography/_typography.scss#L7) has been overlooked to add to the CSS style sheet when including support for Sass.