### PR TITLE
Remove sass :hover and :active states on screen-reader-text

### DIFF
--- a/sass/modules/_accessibility.scss
+++ b/sass/modules/_accessibility.scss
@@ -6,8 +6,6 @@
 	width: 1px;
 	overflow: hidden;
 
-	&:hover,
-	&:active,
 	&:focus {
 		background-color: $color__background-screen;
 		border-radius: 3px;


### PR DESCRIPTION
Hello,

This removes the left-over Sass :hover and :active states on screen-reader-text after a previous commit.

see https://github.com/Automattic/_s/commit/67b2428bbe8ec4d523b1ffa7744a1124cce60966