### PR TITLE
Remove _s_render_title()

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -55,17 +55,4 @@ if ( version_compare( $GLOBALS['wp_version'], '4.1', '<' ) ) :
 		return $title;
 	}
 	add_filter( 'wp_title', '_s_wp_title', 10, 2 );
-
-	/**
-	 * Title shim for sites older than WordPress 4.1.
-	 *
-	 * @link https://make.wordpress.org/core/2014/10/29/title-tags-in-4-1/
-	 * @todo Remove this function when WordPress 4.3 is released.
-	 */
-	function _s_render_title() {
-		?>
-		<title><?php wp_title( '|', true, 'right' ); ?></title>
-		<?php
-	}
-	add_action( 'wp_head', '_s_render_title' );
 endif;


### PR DESCRIPTION
Removing `_s_render_title()`, no longer needed as of 4.3.