### PR TITLE
Add sass missing center alignment clearing

### DIFF
--- a/sass/modules/_alignments.scss
+++ b/sass/modules/_alignments.scss
@@ -11,5 +11,6 @@
 }
 
 .aligncenter {
+	clear: both;
 	@include center-block;
 }


### PR DESCRIPTION
Patch 3 out of 4. Probably overlooked during this commit https://github.com/Automattic/_s/commit/6c47be98c133c911c1533648225e3b720ba260d4 (the introduction of Normalize.css)