### PR TITLE
Added missing period in a load_theme_textdomain() comment.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,7 +20,7 @@ function _s_setup() {
 	 * Make theme available for translation.
 	 * Translations can be filed in the /languages/ directory.
 	 * If you're building a theme based on _s, use a find and replace
-	 * to change '_s' to the name of your theme in all the template files
+	 * to change '_s' to the name of your theme in all the template files.
 	 */
 	load_theme_textdomain( '_s', get_template_directory() . '/languages' );
 


### PR DESCRIPTION
Very minor, but still I believe that there is a period missing from a load_theme_textdomain() comment. Correct me if I'm wrong.