### PR TITLE
Adding _s_comment_nav() template tag.

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -35,17 +35,7 @@ if ( post_password_required() ) {
 			?>
 		</h2>
 
-		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // Are there comments to navigate through? ?>
-		<nav id="comment-nav-above" class="navigation comment-navigation" role="navigation">
-			<h2 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', '_s' ); ?></h2>
-			<div class="nav-links">
-
-				<div class="nav-previous"><?php previous_comments_link( esc_html__( 'Older Comments', '_s' ) ); ?></div>
-				<div class="nav-next"><?php next_comments_link( esc_html__( 'Newer Comments', '_s' ) ); ?></div>
-
-			</div><!-- .nav-links -->
-		</nav><!-- #comment-nav-above -->
-		<?php endif; // Check for comment navigation. ?>
+		<?php _s_comment_nav(); ?>
 
 		<ol class="comment-list">
 			<?php
@@ -56,17 +46,7 @@ if ( post_password_required() ) {
 			?>
 		</ol><!-- .comment-list -->
 
-		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // Are there comments to navigate through? ?>
-		<nav id="comment-nav-below" class="navigation comment-navigation" role="navigation">
-			<h2 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', '_s' ); ?></h2>
-			<div class="nav-links">
-
-				<div class="nav-previous"><?php previous_comments_link( esc_html__( 'Older Comments', '_s' ) ); ?></div>
-				<div class="nav-next"><?php next_comments_link( esc_html__( 'Newer Comments', '_s' ) ); ?></div>
-
-			</div><!-- .nav-links -->
-		</nav><!-- #comment-nav-below -->
-		<?php endif; // Check for comment navigation. ?>
+		<?php _s_comment_nav(); ?>
 
 	<?php endif; // Check for have_comments(). ?>
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -7,6 +7,31 @@
  * @package _s
  */
 
+if ( ! function_exists( '_s_comment_nav' ) ) :
+/**
+ * Prints comment navigation.
+ */
+function _s_comment_nav() {
+	 // Are there comments to navigate through?
+	if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : ?>
+		<nav class="navigation comment-navigation" role="navigation">
+			<h2 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', '_s' ); ?></h2>
+			<div class="nav-links">
+				<?php
+					if ( $prev_link = get_previous_comments_link( __( 'Older Comments', '_s' ) ) ) :
+						printf( '<div class="nav-previous">%s</div>', $prev_link );
+					endif;
+
+					if ( $next_link = get_next_comments_link( __( 'Newer Comments', '_s' ) ) ) :
+						printf( '<div class="nav-next">%s</div>', $next_link );
+					endif;
+				?>
+			</div><!-- .nav-links -->
+		</nav><!-- .comment-navigation -->
+	<?php endif; // Check for comment navigation.
+}
+endif;
+
 if ( ! function_exists( '_s_posted_on' ) ) :
 /**
  * Prints HTML with meta information for the current post-date/time and author.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -19,11 +19,11 @@ function _s_comment_nav() {
 			<div class="nav-links">
 				<?php
 					if ( $prev_link = get_previous_comments_link( __( 'Older Comments', '_s' ) ) ) :
-						printf( '<div class="nav-previous">%s</div>', $prev_link );
+						printf( '<div class="nav-previous">%s</div>', esc_html( $prev_link ) );
 					endif;
 
 					if ( $next_link = get_next_comments_link( __( 'Newer Comments', '_s' ) ) ) :
-						printf( '<div class="nav-next">%s</div>', $next_link );
+						printf( '<div class="nav-next">%s</div>', esc_html( $next_link ) );
 					endif;
 				?>
 			</div><!-- .nav-links -->


### PR DESCRIPTION
This PR is inspired by Twenty Fifteen. I think we can add a template tag for comment navigation. It improves overall readability of comments.php and follows DRY approach. The main downside I can think of is the lack of ID on a *nav* tag. However this is exactly how it is done in Twenty Fifteen. If ID is there for a specific reason I can update a PR and add a parameter to template tag function. Something like this:
```
_s_comment_nav( $id = '' );
```