### PR TITLE
Set skip link focus element's outline to 0 programmatically

### DIFF
--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -24,6 +24,7 @@
 			if ( element ) {
 				if ( ! ( /^(?:a|select|input|button|textarea)$/i.test( element.tagName ) ) ) {
 					element.tabIndex = -1;
+					element.style.outline = '0px';
 				}
 
 				element.focus();


### PR DESCRIPTION
* Not doing so caused some elements to receive an unwanted `outline`.
* Setting this programmatically in the JavaScript avoids any additional CSS and keeps the changes contained to the script.
* It's okay to set the `outline` to 0 here since there's usually no need for a focus outline on an element that only receives focus programmatically.

Fixes #543