### PR TITLE
Fix admin menu rollover issue w/ WP 4.3 & Chrome

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -150,3 +150,12 @@ require get_template_directory() . '/inc/customizer.php';
  * Load Jetpack compatibility file.
  */
 require get_template_directory() . '/inc/jetpack.php';
+
+/**
+ * Fix admin menu rollover issue w/ WordPress 4.3 in Chrome 45/46
+ */
+function chrome_fix() {
+	if( strpos( $_SERVER['HTTP_USER_AGENT'], 'Chrome' ) !== false )
+		wp_add_inline_style( 'wp-admin', '#adminmenu{transform:translateZ(0);}' );
+}
+add_action( 'admin_enqueue_scripts', 'chrome_fix' );


### PR DESCRIPTION
With a simple addition to functions.php, we're able to fix the issue experienced when hovering over links in the admin sidebar when using the latest version of WordPress and Google Chrome.

http://wptavern.com/a-bug-in-chrome-45-causes-wordpress-admin-menu-to-break