### PR TITLE
Remove hfeed from header.php, add to body_class filter. See #740

### DIFF
--- a/header.php
+++ b/header.php
@@ -21,7 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
-<div id="page" class="hfeed site">
+<div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', '_s' ); ?></a>
 
 	<header id="masthead" class="site-header" role="banner">

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -18,6 +18,11 @@ function _s_body_classes( $classes ) {
 	if ( is_multi_author() ) {
 		$classes[] = 'group-blog';
 	}
+	
+	// Adds a class of hfeed to non-singular pages.
+	if ( ! is_singular() ) {
+		$classes[] = 'hfeed';
+	}
 
 	return $classes;
 }


### PR DESCRIPTION
A patch, should we choose to go this route:

* Removes `hfeed` class from header.php
* Move application of the `hfeed` class into a conditional hooked to `body_class`, so it only applies to non-singular pages.
