### PR TITLE
restrict attached image width to 100%

### DIFF
--- a/style.css
+++ b/style.css
@@ -813,7 +813,12 @@ a:active {
 /* Make sure embeds and iframes fit their containers. */
 embed,
 iframe,
-object {
+object,
+.size-auto, 
+.size-full,
+.size-large,
+.size-medium,
+.size-thumbnail {
 	max-width: 100%;
 }
 


### PR DESCRIPTION
In underscores starter theme, we have set $GLOBALS['content_width'] but haven't yet set CSS rule which is recommended by WordPress official site.