### PR TITLE
Only output tagline markup when tagline exists or is_customize_preview

### DIFF
--- a/header.php
+++ b/header.php
@@ -30,8 +30,12 @@
 				<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
 			<?php else : ?>
 				<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+			<?php endif;
+
+			$description = get_bloginfo( 'description', 'display' );
+			if ( $description || is_customize_preview() ) : ?>
+				<p class="site-description"><?php echo $description; ?></p>
 			<?php endif; ?>
-			<p class="site-description"><?php bloginfo( 'description' ); ?></p>
 		</div><!-- .site-branding -->
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">


### PR DESCRIPTION
Fixes #825 

As of WP 4.0 we have `is_customize_preview` which will return true if site is being previewed in the customizer. This allow us to conditionally output the `<p></p>` for the tagline, and it will still work in the customizer preview. 

This PR mimics [how it is handled in Twenty Sixteen](https://github.com/WordPress/twentysixteen/blob/master/header.php#L35-38).
 
