### PR TITLE
respect content-search.php for search result in Jetpack Infinite Scroll

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -32,6 +32,10 @@ add_action( 'after_setup_theme', '_s_jetpack_setup' );
 function _s_infinite_scroll_render() {
 	while ( have_posts() ) {
 		the_post();
-		get_template_part( 'template-parts/content', get_post_format() );
+		if ( is_search() ) :
+		    get_template_part( 'template-parts/content', 'search' );
+		else :
+		    get_template_part( 'template-parts/content', get_post_format() );
+		endif;
 	}
 } // end function _s_infinite_scroll_render


### PR DESCRIPTION
In search results with Jetpack Infinite scroll, search item is supposed to be rendered using `content-search.php`.
Example:
Search result page 1 - `content-search.php`.
Search result page 2 - `content-search.php`.
Search result page 3 - `content-search.php`.
Search result page 4 - `content-search.php`.
and so on.

But currently,
Search result page 1 - `content-search.php`.
Search result page 2 - `content-POSTFORMAT.php`
Search result page 3 - `content-POSTFORMAT.php`
Search result page 4 - `content-POSTFORMAT.php`
This PR fixes this problem which is mentioned in this issue. https://github.com/Automattic/_s/issues/846