### PR TITLE
Fix failing travis build

### DIFF
--- a/header.php
+++ b/header.php
@@ -34,7 +34,7 @@
 
 			$description = get_bloginfo( 'description', 'display' );
 			if ( $description || is_customize_preview() ) : ?>
-				<p class="site-description"><?php echo $description; ?></p>
+				<p class="site-description"><?php echo $description; /* WPCS: xss ok. */ ?></p>
 			<?php endif; ?>
 		</div><!-- .site-branding -->
 


### PR DESCRIPTION
Ignore WPCS output escape warning for description as it *is* already correctly escaped.

Fixes failing travis build.