### PR TITLE
Do not show the outline on the skip link target container

### DIFF
--- a/sass/modules/_accessibility.scss
+++ b/sass/modules/_accessibility.scss
@@ -25,3 +25,8 @@
 		z-index: 100000; /* Above WP toolbar. */
 	}
 }
+
+/* Do not show the outline on the skip link target. */
+#content[tabindex="-1"]:focus {
+	outline: 0;
+}

--- a/style.css
+++ b/style.css
@@ -664,6 +664,11 @@ a:active {
 	z-index: 100000; /* Above WP toolbar. */
 }
 
+/* Do not show the outline on the skip link target. */
+#content[tabindex="-1"]:focus {
+	outline: 0;
+}
+
 /*--------------------------------------------------------------
 # Alignments
 --------------------------------------------------------------*/


### PR DESCRIPTION
* Putting it in style.css solves the issue for our specific skip link, but leaves the outline working on other anchors in case developers need that.
* For discussion, see: https://github.com/Automattic/_s/pull/814
* Related: https://github.com/Automattic/_s/pull/755 and https://github.com/Automattic/_s/pull/604

Fixes #543