### PR TITLE
Conditionally include Jetpack compatibility file.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -149,4 +149,6 @@ require get_template_directory() . '/inc/customizer.php';
 /**
  * Load Jetpack compatibility file.
  */
-require get_template_directory() . '/inc/jetpack.php';
+if ( defined( 'JETPACK__VERSION' ) ) {
+	require get_template_directory() . '/inc/jetpack.php';
+}


### PR DESCRIPTION
Lean loading - including files is _expensive_, so only include the file if it actually makes sense to do so.
