### PR TITLE
Improved _s_categorized_blog() function

### DIFF
--- a/header.php
+++ b/header.php
@@ -21,7 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
-<div id="page" class="hfeed site">
+<div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', '_s' ); ?></a>
 
 	<header id="masthead" class="site-header" role="banner">

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -18,6 +18,11 @@ function _s_body_classes( $classes ) {
 	if ( is_multi_author() ) {
 		$classes[] = 'group-blog';
 	}
+	
+	// Adds a class of hfeed to non-singular pages.
+	if ( ! is_singular() ) {
+		$classes[] = 'hfeed';
+	}
 
 	return $classes;
 }

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -18,7 +18,7 @@ function _s_body_classes( $classes ) {
 	if ( is_multi_author() ) {
 		$classes[] = 'group-blog';
 	}
-	
+
 	// Adds a class of hfeed to non-singular pages.
 	if ( ! is_singular() ) {
 		$classes[] = 'hfeed';

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -32,6 +32,10 @@ add_action( 'after_setup_theme', '_s_jetpack_setup' );
 function _s_infinite_scroll_render() {
 	while ( have_posts() ) {
 		the_post();
-		get_template_part( 'template-parts/content', get_post_format() );
+		if ( is_search() ) :
+		    get_template_part( 'template-parts/content', 'search' );
+		else :
+		    get_template_part( 'template-parts/content', get_post_format() );
+		endif;
 	}
 } // end function _s_infinite_scroll_render

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -83,28 +83,30 @@ endif;
  * @return bool
  */
 function _s_categorized_blog() {
+
+	// Check for transient, if none, go count the categories.
 	if ( false === ( $all_the_cool_cats = get_transient( '_s_categories' ) ) ) {
+
 		// Create an array of all the categories that are attached to posts.
 		$all_the_cool_cats = get_categories( array(
-			'fields'     => 'ids',
-			'hide_empty' => 1,
-			// We only need to know if there is more than one category.
-			'number'     => 2,
+			'fields' => 'ids',
+			'number' => 2, // We only need to know if there is more than one category.
 		) );
 
 		// Count the number of categories that are attached to the posts.
 		$all_the_cool_cats = count( $all_the_cool_cats );
 
+		// Store the number of categories until the transient is flushed with _s_category_transient_flusher().
 		set_transient( '_s_categories', $all_the_cool_cats );
 	}
 
-	if ( $all_the_cool_cats > 1 ) {
-		// This blog has more than 1 category so _s_categorized_blog should return true.
-		return true;
-	} else {
-		// This blog has only 1 category so _s_categorized_blog should return false.
+	// This blog only has 1 category, so _s_categorized_blog and should return false.
+	if ( 1 >= $all_the_cool_cats ) {
 		return false;
 	}
+
+	// This blog has more than 1 category, so _s_categorized_blog should return true.
+	return true;
 }
 
 /**

--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -15,6 +15,7 @@
 @mixin clearfix() {
 	content: "";
 	display: table;
+	table-layout: fixed;
 }
 
 // Clear after (not all clearfix need this also)

--- a/style.css
+++ b/style.css
@@ -708,6 +708,7 @@ a:active {
 .site-footer:after {
 	content: "";
 	display: table;
+	table-layout: fixed;
 }
 
 .clear:after,


### PR DESCRIPTION
- Remove `hide_empty` (the default is 1). https://codex.wordpress.org/Function_Reference/get_categories
- Add more inline comments to help teach folks about using transients.
- Use Yoda conditional to check $all_the_cool_cats to better fit WordPress PHP standards.(https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#yoda-conditions)
- Remove if/else statement. Instead return `false` earlier.