### PR TITLE
Update non-https WordPress URLs. #734

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -10,7 +10,7 @@
 	</a>
 	<?php endif; // End header image check. ?>
  *
- * @link http://codex.wordpress.org/Custom_Headers
+ * @link https://codex.wordpress.org/Custom_Headers
  *
  * @package _s
  */

--- a/languages/_s.pot
+++ b/languages/_s.pot
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: _s 1.0.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/tags/_s\n"
+"Report-Msgid-Bugs-To: http://wordpress.org/tags/_s\n"
 "POT-Creation-Date: 2015-09-16 19:02:07+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/languages/_s.pot
+++ b/languages/_s.pot
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: _s 1.0.0\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/tags/_s\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/tags/_s\n"
 "POT-Creation-Date: 2015-09-16 19:02:07+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/rtl.css
+++ b/rtl.css
@@ -5,7 +5,7 @@ Adding support for language written in a Right To Left (RTL) direction is easy -
 it's just a matter of overwriting all the horizontal positioning attributes
 of your CSS stylesheet in a separate stylesheet file named rtl.css.
 
-http://codex.wordpress.org/Right_to_Left_Language_Support
+https://codex.wordpress.org/Right_to_Left_Language_Support
 
 */
 


### PR DESCRIPTION
Hi, there is a patch for #734. It looks like last 3 changes in urls.