### PR TITLE
Update non-https WordPress URLs without pot file

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -10,7 +10,7 @@
 	</a>
 	<?php endif; // End header image check. ?>
  *
- * @link http://codex.wordpress.org/Custom_Headers
+ * @link https://codex.wordpress.org/Custom_Headers
  *
  * @package _s
  */

--- a/rtl.css
+++ b/rtl.css
@@ -5,7 +5,7 @@ Adding support for language written in a Right To Left (RTL) direction is easy -
 it's just a matter of overwriting all the horizontal positioning attributes
 of your CSS stylesheet in a separate stylesheet file named rtl.css.
 
-http://codex.wordpress.org/Right_to_Left_Language_Support
+https://codex.wordpress.org/Right_to_Left_Language_Support
 
 */
 


### PR DESCRIPTION
There is a patch for the last two instances of http. The another one is in _s.pot file header but I think pot file is auto generated, so every changes will be overwritten. It's for ticket #734