### PR TITLE
Move aside from widgets to the entire sidebar.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -102,8 +102,8 @@ function _s_widgets_init() {
 		'name'          => esc_html__( 'Sidebar', '_s' ),
 		'id'            => 'sidebar-1',
 		'description'   => '',
-		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</aside>',
+		'before_widget' => '<div id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</div>',
 		'before_title'  => '<h2 class="widget-title">',
 		'after_title'   => '</h2>',
 	) );

--- a/functions.php
+++ b/functions.php
@@ -102,8 +102,8 @@ function _s_widgets_init() {
 		'name'          => esc_html__( 'Sidebar', '_s' ),
 		'id'            => 'sidebar-1',
 		'description'   => '',
-		'before_widget' => '<div id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</div>',
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
 		'before_title'  => '<h2 class="widget-title">',
 		'after_title'   => '</h2>',
 	) );

--- a/sidebar.php
+++ b/sidebar.php
@@ -12,6 +12,6 @@ if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 }
 ?>
 
-<div id="secondary" class="widget-area" role="complementary">
+<aside id="secondary" class="widget-area" role="complementary">
 	<?php dynamic_sidebar( 'sidebar-1' ); ?>
-</div><!-- #secondary -->
+</aside><!-- #secondary -->


### PR DESCRIPTION
It appears that the entire sidebar should be one large aside instead of making each widget it's own aside. At least that's how I understand it when reading w3. It would make sense to make each widget it's own aside if not all of the widgets were asides, but otherwise the entire sidebar should be considered one aside.

Plus I think this would make more sense for accessibility including widget titles being h2s because if the entire sidebar had a title that would be the h1.

https://www.w3.org/wiki/HTML/Elements/aside