### PR TITLE
Update 'primary menu' location to 'primary' to simplify for users.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -44,7 +44,7 @@ function _s_setup() {
 
 	// This theme uses wp_nav_menu() in one location.
 	register_nav_menus( array(
-		'primary' => esc_html__( 'Primary Menu', '_s' ),
+		'primary' => esc_html__( 'Primary', '_s' ),
 	) );
 
 	/*

--- a/languages/_s.pot
+++ b/languages/_s.pot
@@ -84,9 +84,8 @@ msgid "Theme: %1$s by %2$s."
 msgstr ""
 
 #: functions.php:47
-#: header.php:38
 #@ _s
-msgid "Primary Menu"
+msgid "Primary"
 msgstr ""
 
 #: functions.php:102
@@ -97,6 +96,11 @@ msgstr ""
 #: header.php:25
 #@ _s
 msgid "Skip to content"
+msgstr ""
+
+#: header.php:38
+#@ _s
+msgid "Primary Menu"
 msgstr ""
 
 #: inc/template-tags.php:28


### PR DESCRIPTION
This replaces #717 with a clean history. I tried rebasing the original branch but a series of merge conflicts made for a messy proposition, so I've submitted the same change with two additions:

* escaped out the translated string
* updated the POT file to account for new strings