### PR TITLE
Add filter to append wp_link_pages to the content

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -27,3 +27,26 @@ function _s_body_classes( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', '_s_body_classes' );
+
+/**
+ * Display page-links for paginated posts before Jetpack share buttons and related posts.
+ *
+ * @param string $content The posts content.
+ * @return string
+ */
+function _s_custom_link_pages( $content ) {
+	if ( ! is_admin() && ! is_feed() && is_main_query() ) {
+		$content .= wp_link_pages( array(
+			'before'      => '<div class="page-links"><span class="page-links-title">' . esc_html__( 'Pages:', '_s' ) . '</span>',
+			'after'       => '</div>',
+			'link_before' => '<span>',
+			'link_after'  => '</span>',
+			'pagelink'    => '<span class="screen-reader-text">' . esc_html__( 'Page', '_s' ) . ' </span>%',
+			'separator'   => '<span class="screen-reader-text">,</span> ',
+			'echo'        => 0,
+		) );
+	}
+
+	return $content;
+}
+add_filter( 'the_content', '_s_custom_link_pages', 1 );

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -15,14 +15,7 @@
 	</header><!-- .entry-header -->
 
 	<div class="entry-content">
-		<?php
-			the_content();
-
-			wp_link_pages( array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', '_s' ),
-				'after'  => '</div>',
-			) );
-		?>
+		<?php the_content(); ?>
 	</div><!-- .entry-content -->
 
 	<footer class="entry-footer">

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -33,11 +33,6 @@
 				wp_kses( __( 'Continue reading %s <span class="meta-nav">&rarr;</span>', '_s' ), array( 'span' => array( 'class' => array() ) ) ),
 				the_title( '<span class="screen-reader-text">"', '"</span>', false )
 			) );
-
-			wp_link_pages( array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', '_s' ),
-				'after'  => '</div>',
-			) );
 		?>
 	</div><!-- .entry-content -->
 


### PR DESCRIPTION
*This was inspired by [Blask](https://wordpress.org/themes/blask/), with additional accessibility parameters from Twentysixteen.*

We currently call wp_link_pages **after** the content. The issue with this is several plugins append to the content (like Jetpack share and related posts) which means we lose control over where we'd like the pagination links to be.

By using a filter we can give wp_link_pages a priority over (or under) plugins. It also helps to keep things DRY and easier to maintain, especially if the theme is using several content-{post-type}.php partials.