### PR TITLE
Remove Normalize right and left padding from figure element.

### DIFF
--- a/sass/typography/_copy.scss
+++ b/sass/typography/_copy.scss
@@ -43,3 +43,7 @@ mark, ins {
 big {
 	font-size: 125%;
 }
+
+figure {
+	margin: 1em 0px;
+}


### PR DESCRIPTION
Normalize resets the `figure` tag as follows:

    figure {
	    margin: 1em 40px;
    }

The caused the [wptest data's full size images with captions](http://wptest.io/demo/category/images/) to overlap my Susy grid in Safari.  Removing the right and left padding from the figure elements fixed the issue.  Now the 1200px wide images are fully contained within the grid and responsive across all views.