### PR TITLE
remove note on HTML5 and H1s following #776

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Here are some tips to consider and to help you write a great report:
 
 * `_s` supports Internet Explorer 9 and greater, as well as the latest two versions of all other major browsers.
 * `_s` is backwards compatible with the two versions prior to the current stable version of WordPress.
-* `_s` uses HTML5 markup. In HTML5, it is common to use multiple `<h1>` elements.
+* `_s` uses HTML5 markup.
 * We decided not to include translations [[#50](https://github.com/Automattic/_s/pull/50)] beyond the exisiting `_s.pot` file, a RTL stylesheet [[#263](https://github.com/Automattic/_s/pull/263)], or editor styles [[#225](https://github.com/Automattic/_s/pull/225)], as they are likely to change during development of an `_s`-based theme.
 
 ## Contibuting code


### PR DESCRIPTION
I think the title is fairly clear, but just to spell it out. `CONTRIBUTING.MD` says:

> _s uses HTML5 markup. **In HTML5, it is common to use multiple \<h1\> elements.**

That second sentence is no longer accurate because of #776.

I could imagine a second PR that modified the sentence to be more complete. Maybe something like this:

> _s uses HTML5 markup whenever possible within the constraints of the aforementioned browser support, supporting assistive technology, or data-backed compelling reasons.

However, we could parse that forever, so let's just remove that sentence for now :)

