### PR TITLE
list all html5 input types. fixes #885

### DIFF
--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -3,6 +3,16 @@ input[type="email"],
 input[type="url"],
 input[type="password"],
 input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"],
 textarea {
 	color: $color__text-input;
 	border: 1px solid $color__border-input;
@@ -13,11 +23,25 @@ textarea {
 	}
 }
 
+select {
+	border: 1px solid #ccc;
+}
+
 input[type="text"],
 input[type="email"],
 input[type="url"],
 input[type="password"],
-input[type="search"] {
+input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"] {
 	padding: 3px;
 }
 

--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -24,7 +24,7 @@ textarea {
 }
 
 select {
-	border: 1px solid #ccc;
+	border: 1px solid $color__border-input;
 }
 
 input[type="text"],

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ Nicolas Gallagher and Jonathan Neal http://necolas.github.com/normalize.css/
 # Clearings
 # Widgets
 # Content
-    ## Posts and pages
+	## Posts and pages
 	## Asides
 	## Comments
 # Infinite scroll
@@ -461,10 +461,24 @@ input[type="email"],
 input[type="url"],
 input[type="password"],
 input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"],
 textarea {
 	color: #666;
 	border: 1px solid #ccc;
 	border-radius: 3px;
+}
+
+select {
+	border: 1px solid #ccc;
 }
 
 input[type="text"]:focus,
@@ -472,6 +486,16 @@ input[type="email"]:focus,
 input[type="url"]:focus,
 input[type="password"]:focus,
 input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="tel"]:focus,
+input[type="range"]:focus,
+input[type="date"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="time"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="color"]:focus,
 textarea:focus {
 	color: #111;
 }
@@ -480,7 +504,17 @@ input[type="text"],
 input[type="email"],
 input[type="url"],
 input[type="password"],
-input[type="search"] {
+input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"] {
 	padding: 3px;
 }
 


### PR DESCRIPTION
- This includes .css and .scss updates.
- I added a border for the `select` element to match other inputs.
- Can anyone explain the padding-left: 3px on [Line 488](https://github.com/Automattic/_s/blob/master/style.css#L488)? It seems to have come in the initial start-styles commit and I can't find any explanation or browser bugs that would explain it. The reason I ask is mostly because it requires listing out every input type twice, the second time solely for the purpose of padding. I'd love to just use the same padding for `textarea` but don't want to break anything. I'm happy to amend if that would be useful.