### PR TITLE
Use `inline-block` rather than `float` for menu items in main navigation

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -49,7 +49,7 @@
 		}
 	}
 	li {
-		float: left;
+		display: inline-block;
 		position: relative;
 
 		&:hover > a,

--- a/style.css
+++ b/style.css
@@ -570,7 +570,7 @@ a:active {
 }
 
 .main-navigation li {
-	float: left;
+	display: inline-block;
 	position: relative;
 }
 


### PR DESCRIPTION
See #454 for additional discussion.