### PR TITLE
Add support for Internet Explorer 7 and Internet Explorer 8

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -53,8 +53,13 @@
 
 	// Each time a menu link is focused or blurred, toggle focus.
 	for ( i = 0, len = links.length; i < len; i++ ) {
-		links[i].addEventListener( 'focus', toggleFocus, true );
-		links[i].addEventListener( 'blur', toggleFocus, true );
+		if (!links[i].addEventListener) {
+			links[i].attachEvent( 'onfocus', toggleFocus);
+			links[i].attachEvent( 'onblur', toggleFocus);
+		} else {
+			links[i].addEventListener( 'focus', toggleFocus, true );
+			links[i].addEventListener( 'blur', toggleFocus, true );
+		}
 	}
 
 	/**


### PR DESCRIPTION
IE7 and IE8 do not support addEventListener, so we have to use attachEvent in this case.