### PR TITLE
Update the replace example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Getting Started
 
 If you want to keep it simple, head over to http://underscores.me and generate your `_s` based theme from there. You just input the name of the theme you want to create, click the "Generate" button, and you get your ready-to-awesomize starter theme.
 
-If you want to set things up manually, download `_s` from GitHub. The first thing you want to do is copy the `_s` directory and change the name to something else (like, say, `coolest-theme-ever`), and then you'll need to do a five-step find and replace on the name in all the templates.
+If you want to set things up manually, download `_s` from GitHub. The first thing you want to do is copy the `_s` directory and change the name to something else (like, say, `megatherium-is-awesome`), and then you'll need to do a five-step find and replace on the name in all the templates.
 
 1. Search for `'_s'` (inside single quotations) to capture the text domain.
 2. Search for `_s_` to capture all the function names.
@@ -32,11 +32,11 @@ If you want to set things up manually, download `_s` from GitHub. The first thin
 
 OR
 
-* Search for: `'_s'` and replace with: `'coolest-theme-ever'`
-* Search for: `_s_` and replace with: `coolest_theme_ever_`
-* Search for: `Text Domain: _s` and replace with: `Text Domain: coolest-theme-ever` in style.css.
-* Search for: <code>&nbsp;_s</code> and replace with: <code>&nbsp;Coolest_Theme_Ever</code>
-* Search for: `_s-` and replace with: `coolest-theme-ever-`
+* Search for: `'_s'` and replace with: `'megatherium-is-awesome'`
+* Search for: `_s_` and replace with: `megatherium_is_awesome_`
+* Search for: `Text Domain: _s` and replace with: `Text Domain: megatherium-is-awesome` in style.css.
+* Search for: <code>&nbsp;_s</code> and replace with: <code>&nbsp;Megatherium_is_Awesome</code>
+* Search for: `_s-` and replace with: `megatherium-is-awesome-`
 
 Then, update the stylesheet header in `style.css` and the links in `footer.php` with your own information. Next, update or delete this readme.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Getting Started
 
 If you want to keep it simple, head over to http://underscores.me and generate your `_s` based theme from there. You just input the name of the theme you want to create, click the "Generate" button, and you get your ready-to-awesomize starter theme.
 
-If you want to set things up manually, download `_s` from GitHub. The first thing you want to do is copy the `_s` directory and change the name to something else (like, say, `megatherium`), and then you'll need to do a five-step find and replace on the name in all the templates.
+If you want to set things up manually, download `_s` from GitHub. The first thing you want to do is copy the `_s` directory and change the name to something else (like, say, `coolest-theme-ever`), and then you'll need to do a five-step find and replace on the name in all the templates.
 
 1. Search for `'_s'` (inside single quotations) to capture the text domain.
 2. Search for `_s_` to capture all the function names.
@@ -32,11 +32,11 @@ If you want to set things up manually, download `_s` from GitHub. The first thin
 
 OR
 
-* Search for: `'_s'` and replace with: `'megatherium'`
-* Search for: `_s_` and replace with: `megatherium_`
-* Search for: `Text Domain: _s` and replace with: `Text Domain: megatherium` in style.css.
-* Search for: <code>&nbsp;_s</code> and replace with: <code>&nbsp;Megatherium</code>
-* Search for: `_s-` and replace with: `megatherium-`
+* Search for: `'_s'` and replace with: `'coolest-theme-ever'`
+* Search for: `_s_` and replace with: `coolest_theme_ever_`
+* Search for: `Text Domain: _s` and replace with: `Text Domain: coolest-theme-ever` in style.css.
+* Search for: <code>&nbsp;_s</code> and replace with: <code>&nbsp;Coolest_Theme_Ever</code>
+* Search for: `_s-` and replace with: `coolest-theme-ever-`
 
 Then, update the stylesheet header in `style.css` and the links in `footer.php` with your own information. Next, update or delete this readme.
 


### PR DESCRIPTION
Many might choose multiple words as theme name, and they may not be sure where they should use a space, a hyphen or an underscore to separate words when doing the initial replacements. The example provided in the README file should cover that scenario.
