### PR TITLE
Fixed margins on Figure tags which was causing x-wide images to overflow content area.

### DIFF
--- a/style.css
+++ b/style.css
@@ -151,7 +151,7 @@ svg:not(:root) {
 }
 
 figure {
-	margin: 1em 40px;
+	margin: 1em 0px;
 }
 
 hr {


### PR DESCRIPTION
I've set left & right margins for the 'Figure' element to 0px (originally 40px) because it was causing extra wide images (i.e. 1200px) to unintentionally overflow the content area. The 40px margin was also causing alignment issues for normal width images.