### PR TITLE
Fixed margin causing x-wide imgs (contained within a figure tag) to overflow content area.

### DIFF
--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -35,4 +35,8 @@ img {
 	max-width: 100%; /* Adhere to container width. */
 }
 
+figure {
+	margin: 1em 0; /* Extra wide images within figure tags don't overflow the content area. */
+}
+
 @import "tables";

--- a/style.css
+++ b/style.css
@@ -411,6 +411,10 @@ img {
 	max-width: 100%; /* Adhere to container width. */
 }
 
+figure {
+	margin: 1em 0; /* Extra wide images within figure tags don't overflow the content area. */
+}
+
 table {
 	margin: 0 0 1.5em;
 	width: 100%;


### PR DESCRIPTION
Added new style rule which sets left & right margins for 'Figure' elements to 0px (currently 40px via normalize.css). Current margin causes extra wide images (i.e. 1200px) to overflow the content area.