### PR TITLE
comments_popup_link arguments

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -61,7 +61,8 @@ function _s_entry_footer() {
 
 	if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
 		echo '<span class="comments-link">';
-		comments_popup_link( esc_html__( 'Leave a comment', '_s' ), esc_html__( '1 Comment', '_s' ), esc_html__( '% Comments', '_s' ) );
+		/* translators: %s: post title */
+		comments_popup_link( sprintf( wp_kses( __( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', '_s' ), array( 'span' => array( 'class' => array() ) ) ), get_the_title() ) );
 		echo '</span>';
 	}
 


### PR DESCRIPTION
Let the Core handle `comments_popup_link` arguments:

1. Better accessibility.
2. Fewer strings to translate in your theme.

Leave the first argument to encourage commenting.  

See issue #907.