### PR TITLE
Correct href for skip to content link

### DIFF
--- a/header.php
+++ b/header.php
@@ -22,7 +22,7 @@
 
 <body <?php body_class(); ?>>
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', '_s' ); ?></a>
+	<a class="skip-link screen-reader-text" href="#main"><?php esc_html_e( 'Skip to content', '_s' ); ?></a>
 
 	<header id="masthead" class="site-header" role="banner">
 		<div class="site-branding">


### PR DESCRIPTION
The ID `content` has been replaced by `main` in https://github.com/Automattic/_s/commit/810e499b9355e1635da11cde14ad401da3da5d15