### PR TITLE
Use delete_category action hook for transient flusher

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -117,5 +117,5 @@ function _s_category_transient_flusher() {
 	// Like, beat it. Dig?
 	delete_transient( '_s_categories' );
 }
-add_action( 'edit_category', '_s_category_transient_flusher' );
+add_action( 'delete_category', '_s_category_transient_flusher' );
 add_action( 'save_post',     '_s_category_transient_flusher' );


### PR DESCRIPTION
When a category is deleted, `edit_category` isn't triggered and editing a category won't affect the count of categories with posts attached to it .
