### PR TITLE
Remove superfluous check from comment template

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -79,15 +79,13 @@ if ( post_password_required() ) {
 		<?php
 		endif; // Check for comment navigation.
 
+		// If comments are closed and there are comments, let's leave a little note, shall we?
+		if ( ! comments_open() ) : ?>
+			<p class="no-comments"><?php esc_html_e( 'Comments are closed.', '_s' ); ?></p>
+		<?php
+		endif;
+
 	endif; // Check for have_comments().
-
-
-	// If comments are closed and there are comments, let's leave a little note, shall we?
-	if ( ! comments_open() && get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) : ?>
-
-		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', '_s' ); ?></p>
-	<?php
-	endif;
 
 	comment_form();
 	?>


### PR DESCRIPTION
If the post type doesn't support comments `get_comments_number()` will already return 0
