### PR TITLE
Add widget description

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -101,7 +101,7 @@ function _s_widgets_init() {
 	register_sidebar( array(
 		'name'          => esc_html__( 'Sidebar', '_s' ),
 		'id'            => 'sidebar-1',
-		'description'   => esc_html__( 'Add widgets here to appear in your sidebar', '_s' ),
+		'description'   => esc_html__( 'Add widgets here.', '_s' ),
 		'before_widget' => '<section id="%1$s" class="widget %2$s">',
 		'after_widget'  => '</section>',
 		'before_title'  => '<h2 class="widget-title">',

--- a/functions.php
+++ b/functions.php
@@ -101,7 +101,7 @@ function _s_widgets_init() {
 	register_sidebar( array(
 		'name'          => esc_html__( 'Sidebar', '_s' ),
 		'id'            => 'sidebar-1',
-		'description'   => '',
+		'description'   => esc_html__( 'Add widgets here to appear in your sidebar', '_s' ),
 		'before_widget' => '<section id="%1$s" class="widget %2$s">',
 		'after_widget'  => '</section>',
 		'before_title'  => '<h2 class="widget-title">',


### PR DESCRIPTION
_From the theme review standpoint (both marketplace and directory)_

I keep seeing authors leave description as-is (empty) and believe that it wouldn't hurt to add something in by default. This is a general description taken from https://github.com/WordPress/twentysixteen/blob/master/functions.php#L150

At the same time it shows good practice how to escape the content and translate the string too.