### PR TITLE
abbr needs text-decoration removed for FF. pre & abbr were styled in 2 places

### DIFF
--- a/style.css
+++ b/style.css
@@ -99,10 +99,6 @@ a:hover {
 	outline: 0;
 }
 
-abbr[title] {
-	border-bottom: 1px dotted;
-}
-
 b,
 strong {
 	font-weight: bold;
@@ -159,13 +155,8 @@ hr {
 	height: 0;
 }
 
-pre {
-	overflow: auto;
-}
-
 code,
 kbd,
-pre,
 samp {
 	font-family: monospace, monospace;
 	font-size: 1em;
@@ -324,6 +315,7 @@ var {
 
 abbr,
 acronym {
+	text-decoration: none;
 	border-bottom: 1px dotted #666;
 	cursor: help;
 }


### PR DESCRIPTION
abbr elements had double lines in Firefox because FF applies text-decoration: dotted and are the only browser supporting it.