### PR TITLE
change .taxonomy-description to more accurate .archive-description

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -18,7 +18,7 @@ get_header(); ?>
 			<header class="page-header">
 				<?php
 					the_archive_title( '<h1 class="page-title">', '</h1>' );
-					the_archive_description( '<div class="taxonomy-description">', '</div>' );
+					the_archive_description( '<div class="archive-description">', '</div>' );
 				?>
 			</header><!-- .page-header -->
 


### PR DESCRIPTION
The class for the `div` containing the archive description was `taxonomy-description`. Since this is a generic `archive.php` template, the description might not be for a taxonomy, and [could be coming from somewhere else](https://wordpress.org/plugins/post-type-archive-descriptions/), a more generic `archive-description` class makes sense.