### PR TITLE
Narrowing the scope of the transient flusher to post types that have category as a taxonomy

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -119,4 +119,18 @@ function _s_category_transient_flusher() {
 	delete_transient( '_s_categories' );
 }
 add_action( 'edit_category', '_s_category_transient_flusher' );
-add_action( 'save_post_post', '_s_category_transient_flusher' );
+
+/**
+ * Queue the add_action for save_post_{post_type} only if the post type has the 'category' taxonomy
+ */
+function _s_queue_transient_flusher() {
+	$post_types = get_post_types( array( 'public' => true, '_builtin' => true ), 'names' );
+	foreach ( $post_types as $post_type ) {
+		$taxonomies = get_object_taxonomies( $post_type );
+		if ( in_array( 'category', $taxonomies ) ) {
+			add_action( 'save_post_' . $post_type, '_s_category_transient_flusher' );
+		}
+	}	
+}
+// Hooking late on init to let plugins register custom posts types first
+add_action( 'init', '_s_queue_transient_flusher', 9999 );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -119,4 +119,4 @@ function _s_category_transient_flusher() {
 	delete_transient( '_s_categories' );
 }
 add_action( 'edit_category', '_s_category_transient_flusher' );
-add_action( 'save_post_post',     '_s_category_transient_flusher' );
+add_action( 'save_post_post', '_s_category_transient_flusher' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -119,4 +119,4 @@ function _s_category_transient_flusher() {
 	delete_transient( '_s_categories' );
 }
 add_action( 'edit_category', '_s_category_transient_flusher' );
-add_action( 'save_post',     '_s_category_transient_flusher' );
+add_action( 'save_post_post',     '_s_category_transient_flusher' );


### PR DESCRIPTION
Currently in s_category_transient_flusher, the transient is flushed whenever any post type is saved
(pages for example). This narrows the focus to posts only using the
save_post_{post_type} hook which has been around since WP 3.7
