### PR TITLE
Fix menu touch taps

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -78,4 +78,35 @@
 			self = self.parentElement;
 		}
 	}
+	
+	/**
+	 * Toggles `focus` class to allow submenu access on tablets.
+	 */
+	( function ( container ) {
+		var touchStartFn,
+			parentLink = container.querySelectorAll( '.menu-item-has-children > a, .page_item_has_children > a' );
+
+		if ( 'ontouchstart' in window ) {
+			touchStartFn = function( e ) {
+				var menuItem = this.parentNode;
+
+				if ( ! menuItem.classList.contains( 'focus' ) ) {
+					e.preventDefault();
+					for( var i = 0; i < menuItem.parentNode.children.length; ++i ) {
+						if ( menuItem === menuItem.parentNode.children[i] ) {
+							continue;
+						}
+						menuItem.parentNode.children[i].classList.remove( 'focus' );
+					}
+					menuItem.classList.add( 'focus' );
+				} else {
+					menuItem.classList.remove( 'focus' );
+				}
+			};
+
+			for ( var i = 0; i < parentLink.length; ++i ) {
+				parentLink[i].addEventListener( 'touchstart', touchStartFn, false );
+			}
+		}
+	} ( container ) );
 } )();


### PR DESCRIPTION
Add JS function to handle toggling `.focus` class on parent menu items so child menus can be accessed on tablets. Props @iamtakashi