### PR TITLE
Only load pingback URL if it's a singlar page

### DIFF
--- a/header.php
+++ b/header.php
@@ -15,7 +15,9 @@
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="profile" href="http://gmpg.org/xfn/11">
+<?php if ( is_singular() && pings_open( get_queried_object() ) ) : ?>
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
+<?php endif; ?>
 
 <?php wp_head(); ?>
 </head>


### PR DESCRIPTION
Only load pingback URL if it's a singular page and pings are open. Twenty Sixteen is doing the same. Similar to #853 but a better way to do it.