### PR TITLE
Navigation - menu ancestor fix

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -63,7 +63,8 @@
 
 	.current_page_item > a,
 	.current-menu-item > a,
-	.current_page_ancestor > a {
+	.current-page-ancestor > a,
+	.current-menu-ancestor > a {
 	}
 }
 


### PR DESCRIPTION
Renamed
.current_page_ancestor > a
to
.current-page-ancestor > a,
