### PR TITLE
Fix skip to content link.

### DIFF
--- a/header.php
+++ b/header.php
@@ -22,7 +22,7 @@
 
 <body <?php body_class(); ?>>
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#main"><?php esc_html_e( 'Skip to content', '_s' ); ?></a>
+	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', '_s' ); ?></a>
 
 	<header id="masthead" class="site-header" role="banner">
 		<div class="site-branding">


### PR DESCRIPTION
* Reverts this commit: https://github.com/Automattic/_s/pull/927 The issue for that, #928 referenced an old commit. The `id` is still in the source though.
* Brought up by #982. The `id` was correct, should not have been changed and this fixes everything.

Fixes #982