### PR TITLE
Remove deprecated constant HEADER_TEXTCOLOR

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -43,9 +43,9 @@ function _s_header_style() {
 
 	/*
 	 * If no custom options for text are set, let's bail.
-	 * get_header_textcolor() options: Any hex value, 'blank' to hide text. Default: HEADER_TEXTCOLOR.
+	 * get_header_textcolor() options: Any hex value, 'blank' to hide text. Default: add_theme_support( 'custom-header' ).
 	 */
-	if ( HEADER_TEXTCOLOR === $header_text_color ) {
+	if ( get_theme_support( 'custom-header', 'default-text-color' ) === $header_text_color ) {
 		return;
 	}
 


### PR DESCRIPTION
The constant was deprecated in WP 3.4.

> Constants are lame. Don't reference them. This is just for backward compatibility.

from [/wp-includes/theme.php#L1645](https://github.com/WordPress/WordPress/blob/master/wp-includes/theme.php#L1645)

We are adding a check to the new Theme Check to not allow deprecated constants. https://github.com/WPTRT/WordPress-Coding-Standards/pull/30
