### PR TITLE
Responsive method for _s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-style.css.map

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+style.css.map

--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -6,17 +6,21 @@ input[type="submit"] {
 	border-color: $color__border-button;
 	border-radius: 3px;
 	background: $color__background-button;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), inset 0 15px 17px rgba(255, 255, 255, 0.5), inset 0 -5px 12px rgba(0, 0, 0, 0.05);
 	color: rgba(0, 0, 0, .8);
 	@include font-size(0.75);
 	line-height: 1;
 	padding: .6em 1em .4em;
+	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
 
 	&:hover {
 		border-color: $color__border-button-hover;
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 15px 17px rgba(255, 255, 255, 0.8), inset 0 -5px 12px rgba(0, 0, 0, 0.02);
 	}
 
 	&:active,
 	&:focus {
 		border-color: $color__border-button-focus;
+		box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.15);
 	}
 }

--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -6,21 +6,17 @@ input[type="submit"] {
 	border-color: $color__border-button;
 	border-radius: 3px;
 	background: $color__background-button;
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), inset 0 15px 17px rgba(255, 255, 255, 0.5), inset 0 -5px 12px rgba(0, 0, 0, 0.05);
 	color: rgba(0, 0, 0, .8);
 	@include font-size(0.75);
 	line-height: 1;
 	padding: .6em 1em .4em;
-	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
 
 	&:hover {
 		border-color: $color__border-button-hover;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 15px 17px rgba(255, 255, 255, 0.8), inset 0 -5px 12px rgba(0, 0, 0, 0.02);
 	}
 
 	&:active,
 	&:focus {
 		border-color: $color__border-button-focus;
-		box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.15);
 	}
 }

--- a/sass/responsive/_responsive.scss
+++ b/sass/responsive/_responsive.scss
@@ -1,0 +1,19 @@
+/*--------------------------------------------------------------
+## Mobile first approach, so no files for mobile screens
+--------------------------------------------------------------*/
+
+
+/* Small devices (tablets and up) */
+@media (min-width: $screen__small-break) { 
+	@import "small";
+}
+
+/* Medium devices (desktops and up) */
+@media (min-width: $screen__medium-break) {
+	@import "medium";
+}
+
+/* Large devices (large desktops and up) */
+@media (min-width: $screen__large-break) {
+	@import "large";
+}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -104,3 +104,8 @@ Nicolas Gallagher and Jonathan Neal http://necolas.github.com/normalize.css/
 # Media
 --------------------------------------------------------------*/
 @import "media/media";
+
+/*--------------------------------------------------------------
+# Responsive
+--------------------------------------------------------------*/
+@import "responsive/responsive";

--- a/sass/variables-site/_structure.scss
+++ b/sass/variables-site/_structure.scss
@@ -1,2 +1,6 @@
 $size__site-main: 100%;
 $size__site-sidebar: 25%;
+
+$screen__small-break: 768px;
+$screen__medium-break: 992px;
+$screen__large-break: 1200px;

--- a/style.css
+++ b/style.css
@@ -421,13 +421,11 @@ input[type="submit"] {
 	border-color: #ccc #ccc #bbb;
 	border-radius: 3px;
 	background: #e6e6e6;
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), inset 0 15px 17px rgba(255, 255, 255, 0.5), inset 0 -5px 12px rgba(0, 0, 0, 0.05);
 	color: rgba(0, 0, 0, .8);
 	font-size: 12px;
 	font-size: 0.75rem;
 	line-height: 1;
 	padding: .6em 1em .4em;
-	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
 button:hover,
@@ -435,7 +433,6 @@ input[type="button"]:hover,
 input[type="reset"]:hover,
 input[type="submit"]:hover {
 	border-color: #ccc #bbb #aaa;
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 15px 17px rgba(255, 255, 255, 0.8), inset 0 -5px 12px rgba(0, 0, 0, 0.02);
 }
 
 button:focus,
@@ -447,7 +444,6 @@ input[type="button"]:active,
 input[type="reset"]:active,
 input[type="submit"]:active {
 	border-color: #aaa #bbb #bbb;
-	box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.15);
 }
 
 input[type="text"],

--- a/style.css
+++ b/style.css
@@ -421,11 +421,13 @@ input[type="submit"] {
 	border-color: #ccc #ccc #bbb;
 	border-radius: 3px;
 	background: #e6e6e6;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), inset 0 15px 17px rgba(255, 255, 255, 0.5), inset 0 -5px 12px rgba(0, 0, 0, 0.05);
 	color: rgba(0, 0, 0, .8);
 	font-size: 12px;
 	font-size: 0.75rem;
 	line-height: 1;
 	padding: .6em 1em .4em;
+	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
 button:hover,
@@ -433,6 +435,7 @@ input[type="button"]:hover,
 input[type="reset"]:hover,
 input[type="submit"]:hover {
 	border-color: #ccc #bbb #aaa;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 15px 17px rgba(255, 255, 255, 0.8), inset 0 -5px 12px rgba(0, 0, 0, 0.02);
 }
 
 button:focus,
@@ -444,6 +447,7 @@ input[type="button"]:active,
 input[type="reset"]:active,
 input[type="submit"]:active {
 	border-color: #aaa #bbb #bbb;
+	box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.15);
 }
 
 input[type="text"],


### PR DESCRIPTION
I assume it is a bit cocky to propose this, but during education of people on several meetups and workshops I noticed they are hard adopters of responsive design from the start. Maybe we need to push them a bit further and to set a base for responsive _s.

Also, I am sorry if I am stupid and this is not the way it should be done. I have tried this method in my work and with attendees of the wp gatherings, and it seems they adopt it well.

Also, I am aware that _s is just a pure skeleton for wp theme, and this is maybe an overhead, but it maybe help someone.

Short description of the method:

Added responsive folder to the sass folder. Main _responsive.scss file is called from style.scss. Responsive file contains media queries which calls the individual files for every screen size. Break points are easily changeable via variables in _structure.scss file in the variables folder.

Advantages:
- Every theme will be already prepared for the responsive
- No worries about braces {} of the media queries
- Easy changeable break points via variables

**P.S. This change has no huge effect on the CSS file or we can maybe include the empty media queries.**
