### PR TITLE
Adding support for .current-page-ancestor

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -66,6 +66,7 @@
 	.current_page_item > a,
 	.current-menu-item > a,
 	.current_page_ancestor > a,
+	.current-page-ancestor > a,
 	.current-menu-ancestor > a {
 	}
 }


### PR DESCRIPTION
Adding a rule for .main-navigation .current-page-ancestor > a
