### PR TITLE
Make the `content.php` more flexible

### DIFF
--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -12,7 +12,7 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
 		<?php
-		if ( is_single() ) :
+		if ( is_singular() ) :
 			the_title( '<h1 class="entry-title">', '</h1>' );
 		else :
 			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );


### PR DESCRIPTION
The fallback `content.php` file currently only works out of the box for non-hierarchical custom post types (similar to posts), as there's a `content-page.php` shipped with _s.

Since CPTs can be hierarchical as well, it makes sense to check for `is_singular()` here to avoid outputting linked `<h2>` tags on non-archive pages.
