### PR TITLE
Update Normalize site link

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,7 +17,7 @@ _s is based on Underscores http://underscores.me/, (C) 2012-2016 Automattic, Inc
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
-Nicolas Gallagher and Jonathan Neal http://necolas.github.com/normalize.css/
+Nicolas Gallagher and Jonathan Neal http://necolas.github.io/normalize.css/
 */
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
Normalize site link, although the .com redirects to .io, but I think there's no harm to update to the current site link 
