### PR TITLE
Translation fix for a comment string

### DIFF
--- a/languages/_s.pot
+++ b/languages/_s.pot
@@ -136,17 +136,17 @@ msgstr ""
 msgid "Tagged %1$s"
 msgstr ""
 
-#: inc/template-tags.php:64
+#: inc/template-tags.php:65
 #@ _s
-msgid "Leave a comment"
+msgid "Leave a Comment<span class=\"screen-reader-text\"> on %s</span>"
 msgstr ""
 
-#: inc/template-tags.php:64
+#: inc/template-tags.php:65
 #@ _s
 msgid "1 Comment"
 msgstr ""
 
-#: inc/template-tags.php:64
+#: inc/template-tags.php:65
 #@ _s
 msgid "% Comments"
 msgstr ""


### PR DESCRIPTION
Hi, 

Here's a fix for the missing translation I found and reported here https://github.com/Automattic/_s/issues/1005. 

I hope everything is fine since it's my first pull request on Github ;).

Keep up the good work on _s 👍
