### PR TITLE
Minor automated testing tweaks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,10 @@ matrix:
         # aliased to a recent 5.6.x version
         - php: '5.6'
           env: SNIFF=1
-        # aliased to a recent 7.x version
+        # aliased to a recent 7.0.x version
         - php: '7.0'
+        # aliased to a recent 7.1.x version
+        - php: '7.1'
         # aliased to a recent hhvm version
         - php: 'hhvm'
 

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -14,5 +14,6 @@
 	</rule>
 
 	<!-- Include sniffs for PHP cross-version compatibility. -->
+	<config name="testVersion" value="5.2-99.0"/>
 	<rule ref="PHPCompatibility"/>
 </ruleset>


### PR DESCRIPTION
- Add PHP 7.1 to the travis test matrix as it will be released soon.
- Set `testVersion` for PHPCompatibility so we receive the messages for the right PHP versions.
