### PR TITLE
Fix translatability of comments title.

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -30,11 +30,13 @@ if ( post_password_required() ) {
 				$comment_count = get_comments_number();
 				if ( 1 === $comment_count ) {
 					printf(
+						/* translators: 1: title. */
 						esc_html_e( 'One thought on &ldquo;%1$s&rdquo;', '_s' ),
 						'<span>' . get_the_title() . '</span>'
 					);
 				} else {
 					printf( // WPCS: XSS OK.
+						/* translators: 1: comment count number, 2: title. */
 						esc_html( _nx( '%1$s thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', $comment_count, 'comments title', '_s' ) ),
 						number_format_i18n( $comment_count ),
 						'<span>' . get_the_title() . '</span>'

--- a/comments.php
+++ b/comments.php
@@ -27,11 +27,19 @@ if ( post_password_required() ) {
 	if ( have_comments() ) : ?>
 		<h2 class="comments-title">
 			<?php
-				printf( // WPCS: XSS OK.
-					esc_html( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', '_s' ) ),
-					number_format_i18n( get_comments_number() ),
-					'<span>' . get_the_title() . '</span>'
-				);
+				$comment_count = get_comments_number();
+				if ( 1 === $comment_count ) {
+					printf(
+						esc_html_e( 'One thought on &ldquo;%1$s&rdquo;', '_s' ),
+						'<span>' . get_the_title() . '</span>'
+					);
+				} else {
+					printf( // WPCS: XSS OK.
+						esc_html( _nx( '%1$s thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', $comment_count, 'comments title', '_s' ) ),
+						number_format_i18n( $comment_count ),
+						'<span>' . get_the_title() . '</span>'
+					);
+				}
 			?>
 		</h2><!-- .comments-title -->
 

--- a/languages/_s.pot
+++ b/languages/_s.pot
@@ -4,13 +4,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: _s 1.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/tags/_s\n"
-"POT-Creation-Date: 2016-02-14 21:43:07+00:00\n"
+"POT-Creation-Date: 2016-12-23 16:00+0100\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2015-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2016-12-23 16:00+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 
 #: 404.php:17
 #@ _s
@@ -34,34 +35,39 @@ msgstr ""
 msgid "Try looking in the monthly archives. %1$s"
 msgstr ""
 
-#: comments.php:31
+#. translators: 1: title.
+#: comments.php:34
+#, php-format
+#@ _s
+msgid "One thought on &ldquo;%1$s&rdquo;"
+msgstr ""
+
+#. translators: 1: comment count number, 2: title.
+#: comments.php:40
 #, php-format
 #@ _s
 msgctxt "comments title"
-msgid "One thought on &ldquo;%2$s&rdquo;"
+msgid "%1$s thought on &ldquo;%2$s&rdquo;"
 msgid_plural "%1$s thoughts on &ldquo;%2$s&rdquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: comments.php:40
-#: comments.php:61
+#: comments.php:50 comments.php:71
 #@ _s
 msgid "Comment navigation"
 msgstr ""
 
-#: comments.php:43
-#: comments.php:64
+#: comments.php:53 comments.php:74
 #@ _s
 msgid "Older Comments"
 msgstr ""
 
-#: comments.php:44
-#: comments.php:65
+#: comments.php:54 comments.php:75
 #@ _s
 msgid "Newer Comments"
 msgstr ""
 
-#: comments.php:78
+#: comments.php:88
 #@ _s
 msgid "Comments are closed."
 msgstr ""
@@ -88,17 +94,22 @@ msgstr ""
 msgid "Primary"
 msgstr ""
 
-#: functions.php:102
+#: functions.php:93
 #@ _s
 msgid "Sidebar"
 msgstr ""
 
-#: header.php:25
+#: functions.php:95
+#@ _s
+msgid "Add widgets here."
+msgstr ""
+
+#: header.php:24
 #@ _s
 msgid "Skip to content"
 msgstr ""
 
-#: header.php:45
+#: header.php:44
 #@ _s
 msgid "Primary Menu"
 msgstr ""
@@ -118,8 +129,7 @@ msgid "by %s"
 msgstr ""
 
 #. translators: used between list items, there is a space after the comma
-#: inc/template-tags.php:50
-#: inc/template-tags.php:56
+#: inc/template-tags.php:50 inc/template-tags.php:56
 #@ _s
 msgid ", "
 msgstr ""
@@ -136,24 +146,15 @@ msgstr ""
 msgid "Tagged %1$s"
 msgstr ""
 
+#. translators: %s: post title
 #: inc/template-tags.php:65
+#, php-format
 #@ _s
 msgid "Leave a Comment<span class=\"screen-reader-text\"> on %s</span>"
 msgstr ""
 
-#: inc/template-tags.php:65
-#@ _s
-msgid "1 Comment"
-msgstr ""
-
-#: inc/template-tags.php:65
-#@ _s
-msgid "% Comments"
-msgstr ""
-
 #. translators: %s: Name of current post
-#: inc/template-tags.php:71
-#: template-parts/content-page.php:33
+#: inc/template-tags.php:72 template-parts/content-page.php:34
 #, php-format
 #@ _s
 msgid "Edit %s"
@@ -186,13 +187,12 @@ msgstr ""
 msgid "It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help."
 msgstr ""
 
-#: template-parts/content-page.php:22
-#: template-parts/content.php:38
+#: template-parts/content-page.php:22 template-parts/content.php:38
 #@ _s
 msgid "Pages:"
 msgstr ""
 
-#. translators: %s: Name of current post. 
+#. translators: %s: Name of current post.
 #: template-parts/content.php:33
 #, php-format
 #@ _s
@@ -200,6 +200,7 @@ msgid "Continue reading %s <span class=\"meta-nav\">&rarr;</span>"
 msgstr ""
 
 #. Theme Name of the plugin/theme
+#@ _s
 msgid "_s"
 msgstr ""
 


### PR DESCRIPTION
As per the guidelines in https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals

> Note that some languages use the singular form for other numbers (e.g. 21, 31 and so on, much like '21st', '31st' in English). If you would like to special case the singular, check for it specifically

This fixes an error notice which WPCS will start throwing once the - soon to be released - 0.10.0 version has become stable.
