### PR TITLE
Allow for content-{post_type}.php template files in single.php

### DIFF
--- a/single.php
+++ b/single.php
@@ -15,7 +15,7 @@ get_header(); ?>
 		<?php
 		while ( have_posts() ) : the_post();
 
-			get_template_part( 'template-parts/content', get_post_format() );
+			get_template_part( 'template-parts/content', get_post_type() );
 
 			the_post_navigation();
 


### PR DESCRIPTION
I often want to modify the contents of `content.php` for a specific post _type_. In fact, for me, this is more common than wanting to modify `content.php` by post _format_. Currently, that means having to create a new `single-{post_type}.php` file, often for the sole purpose of changing the `get_template_part()` call.

This change allows for the use of `template-parts/content-{post_type}.php` (e.g. `content-jetpack-portfolio.php`) without having to create separate `single-{post_type}.php` files. What previously required two new files and much more duplicated code, now only takes one. This PR maintains the existing `content-{post_format}.php` file ability while adding the `post_type` extensions.
