### PR TITLE
Change primary menu idea to menu-1

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -44,7 +44,7 @@ function _s_setup() {
 
 	// This theme uses wp_nav_menu() in one location.
 	register_nav_menus( array(
-		'primary' => esc_html__( 'Primary', '_s' ),
+		'menu-1' => esc_html__( 'Primary', '_s' ),
 	) );
 
 	/*

--- a/header.php
+++ b/header.php
@@ -42,7 +42,7 @@
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">
 			<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php esc_html_e( 'Primary Menu', '_s' ); ?></button>
-			<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu' ) ); ?>
+			<?php wp_nav_menu( array( 'theme_location' => 'menu-1', 'menu_id' => 'primary-menu' ) ); ?>
 		</nav><!-- #site-navigation -->
 	</header><!-- #masthead -->
 


### PR DESCRIPTION
This makes _s align with the new [Theme User Experience Requirements](https://developer.wordpress.com/themes/#tux). The logic seems quite solid on its own:

> Menu IDs should take the format of menu-1, menu-2, etc. **Reason:** Consistency across themes means that a user can switch themes and not have to reassign their menu to the theme’s menu location. It also allows easier readability in code.

There's no reason _not_ to make _s themes as portable as possible, and this encourages an easy-to-infer naming scheme.
