### PR TITLE
Remove Button Shadow Styling

### DIFF
--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -6,21 +6,17 @@ input[type="submit"] {
 	border-color: $color__border-button;
 	border-radius: 3px;
 	background: $color__background-button;
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), inset 0 15px 17px rgba(255, 255, 255, 0.5), inset 0 -5px 12px rgba(0, 0, 0, 0.05);
 	color: rgba(0, 0, 0, .8);
 	@include font-size(0.75);
 	line-height: 1;
 	padding: .6em 1em .4em;
-	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
 
 	&:hover {
 		border-color: $color__border-button-hover;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 15px 17px rgba(255, 255, 255, 0.8), inset 0 -5px 12px rgba(0, 0, 0, 0.02);
 	}
 
 	&:active,
 	&:focus {
 		border-color: $color__border-button-focus;
-		box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.15);
 	}
 }

--- a/style.css
+++ b/style.css
@@ -421,13 +421,11 @@ input[type="submit"] {
 	border-color: #ccc #ccc #bbb;
 	border-radius: 3px;
 	background: #e6e6e6;
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), inset 0 15px 17px rgba(255, 255, 255, 0.5), inset 0 -5px 12px rgba(0, 0, 0, 0.05);
 	color: rgba(0, 0, 0, .8);
 	font-size: 12px;
 	font-size: 0.75rem;
 	line-height: 1;
 	padding: .6em 1em .4em;
-	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
 button:hover,
@@ -435,7 +433,6 @@ input[type="button"]:hover,
 input[type="reset"]:hover,
 input[type="submit"]:hover {
 	border-color: #ccc #bbb #aaa;
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 15px 17px rgba(255, 255, 255, 0.8), inset 0 -5px 12px rgba(0, 0, 0, 0.02);
 }
 
 button:focus,
@@ -447,7 +444,6 @@ input[type="button"]:active,
 input[type="reset"]:active,
 input[type="submit"]:active {
 	border-color: #aaa #bbb #bbb;
-	box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.15);
 }
 
 input[type="text"],


### PR DESCRIPTION
I would really like to hear your opinion on this. Thanks folks!

I think gradient styling of the buttons are unnecessary. They have been added long ago as background gradients, then changed in 2012 (#39 by @hugobaeta was merged on 14 Sep 2012 ). Now I think in the flat world we need to completely get rid of those gradients on the buttons.

Reasons for this:
- I assume everyone has it's own styling of the buttons
- I think people rarely uses that box shadow effect on buttons and text
- If we remove it we get flat buttons design. Which is much more used. 
- I remove it in every single project (most impotant reason :) )

But really, I think this styling only complicates _s theme unnecessarily.

Maybe we should add only this code to :hover pseudo class:
`background: lighten($color__background-button, 5%);`
To create more visible hover effect.
