### PR TITLE
Remove period from file header

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sample implementation of the Custom Header feature.
+ * Sample implementation of the Custom Header feature
  *
  * You can add an optional custom header image to header.php like so ...
  *

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * _s Theme Customizer.
+ * _s Theme Customizer
  *
  * @package _s
  */

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Custom functions that act independently of the theme templates.
+ * Custom functions that act independently of the theme templates
  *
  * Eventually, some of the functionality here could be replaced by core features.
  *

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Jetpack Compatibility File.
+ * Jetpack Compatibility File
  *
  * @link https://jetpack.com/
  *

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Custom template tags for this theme.
+ * Custom template tags for this theme
  *
  * Eventually, some of the functionality here could be replaced by core features.
  *

--- a/inc/wpcom.php
+++ b/inc/wpcom.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WordPress.com-specific functions and definitions.
+ * WordPress.com-specific functions and definitions
  *
  * This file is centrally included from `wp-content/mu-plugins/wpcom-theme-compat.php`.
  *


### PR DESCRIPTION
According to [WordPress PHP Documentation Standards ](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#6-file-headers) there shouldn't be period after the file header
