### PR TITLE
Remove period from file header

### DIFF
--- a/404.php
+++ b/404.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying 404 pages (not found).
+ * The template for displaying 404 pages (not found)
  *
  * @link https://codex.wordpress.org/Creating_an_Error_404_Page
  *

--- a/archive.php
+++ b/archive.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying archive pages.
+ * The template for displaying archive pages
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *

--- a/comments.php
+++ b/comments.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying comments.
+ * The template for displaying comments
  *
  * This is the template that displays the area of the page that contains both the current comments
  * and the comment form.

--- a/footer.php
+++ b/footer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying the footer.
+ * The template for displaying the footer
  *
  * Contains the closing of the #content div and all content after.
  *

--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * _s functions and definitions.
+ * _s functions and definitions
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *

--- a/header.php
+++ b/header.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The header for our theme.
+ * The header for our theme
  *
  * This is the template that displays all of the <head> section and everything up until <div id="content">
  *

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The main template file.
+ * The main template file
  *
  * This is the most generic template file in a WordPress theme
  * and one of the two required files for a theme (the other being style.css).

--- a/page.php
+++ b/page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying all pages.
+ * The template for displaying all pages
  *
  * This is the template that displays all pages by default.
  * Please note that this is the WordPress construct of pages

--- a/search.php
+++ b/search.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying search results pages.
+ * The template for displaying search results pages
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#search-result
  *

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The sidebar containing the main widget area.
+ * The sidebar containing the main widget area
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *

--- a/single.php
+++ b/single.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying all single posts.
+ * The template for displaying all single posts
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 /*
-Theme Name: _s
+Theme Name: _sss
 Theme URI: http://underscores.me/
 Author: Automattic
 Author URI: http://automattic.com/

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template part for displaying a message that posts cannot be found.
+ * Template part for displaying a message that posts cannot be found
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template part for displaying page content in page.php.
+ * Template part for displaying page content in page.php
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template part for displaying results in search pages.
+ * Template part for displaying results in search pages
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template part for displaying posts.
+ * Template part for displaying posts
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *


### PR DESCRIPTION
According to [WordPress PHP Documentation Standards ](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#6-file-headers) there shouldn't be period after the file header

Fixes issue #1030 
