### PR TITLE
Update .site-title styles instead of anchor in customizer script

### DIFF
--- a/js/customizer.js
+++ b/js/customizer.js
@@ -24,12 +24,12 @@
 	wp.customize( 'header_textcolor', function( value ) {
 		value.bind( function( to ) {
 			if ( 'blank' === to ) {
-				$( '.site-title a, .site-description' ).css( {
+				$( '.site-title, .site-description' ).css( {
 					'clip': 'rect(1px, 1px, 1px, 1px)',
 					'position': 'absolute'
 				} );
 			} else {
-				$( '.site-title a, .site-description' ).css( {
+				$( '.site-title, .site-description' ).css( {
 					'clip': 'auto',
 					'position': 'relative'
 				} );


### PR DESCRIPTION
See issue https://github.com/Automattic/_s/issues/990 from @samikeijonen 

Currently the customizer script visually hides/shows the `a` element inside the `.site-title`, which is not consistent with the actual CSS output by inc/custom-header.php, which hides/shows the `.site-title` element itself. This change makes the customizer consistent with the PHP changes.
