### PR TITLE
Security update: Remove automated Version numbers on scripts and styles

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -99,6 +99,11 @@ function _s_widgets_init() {
 add_action( 'widgets_init', '_s_widgets_init' );
 
 /**
+ * Implement WordPres version stripping from theme styles & scripts.
+ */
+//require get_template_directory() . '/inc/version-strip.php';
+
+/**
  * Enqueue scripts and styles.
  */
 function _s_scripts() {

--- a/inc/version-strip.php
+++ b/inc/version-strip.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Remove the auto generated wordpress versioning in theme i.e.
+ * Remove meta data generator version number
+ *
+ * Remove all strings attached to css and scripts in theme 
+ * except those of installed plugins and theme purposed version addition.
+ *
+ * @package _s
+ */
+
+/**
+ * Setup function to query version attachements to scripts and style
+ *
+ * @package _s
+ */
+
+function _s_remove_wp_version_strings( $src ) {
+    global $wp_version;
+    
+    //check for PHP version
+    parse_str( parse_url($src, PHP_URL_QUERY), $ver_query );
+    
+    //Check if current version number is appended to file
+    if ( !empty( $ver_query['ver'] ) && $ver_query['ver'] === $wp_version ) {
+        
+        //Strip version number from file
+        $src = remove_query_arg( 'ver', $src );
+    }
+    
+    return $src; //Return the clean file
+}
+
+//Filter for footer scripts files
+add_filter( 'script_loader_src', '_s_remove_wp_version_strings' );
+    
+//Filter for styles files
+add_filter( 'style_loader_src', '_s_remove_wp_version_strings' );
+
+//Strip meta data generator WordPress version in <head>
+function _s_remove_meta_version()  {
+    return '';
+}
+
+add_filter( 'the_generator', '_s_remove_meta_version' );

--- a/inc/version-strip.php
+++ b/inc/version-strip.php
@@ -12,7 +12,6 @@
 /**
  * Setup function to query version attachements to scripts and style
  *
- * @package _s
  */
 
 function _s_remove_wp_version_strings( $src ) {
@@ -31,10 +30,8 @@ function _s_remove_wp_version_strings( $src ) {
     return $src; //Return the clean file
 }
 
-//Filter for footer scripts files
+//Filter for footer scripts and styles files using the same function
 add_filter( 'script_loader_src', '_s_remove_wp_version_strings' );
-    
-//Filter for styles files
 add_filter( 'style_loader_src', '_s_remove_wp_version_strings' );
 
 //Strip meta data generator WordPress version in <head>


### PR DESCRIPTION
I have noticed that  several users of WordPress do not update their core on live production even when prompted too in the dashboard. Some security folks argue that this could be a problem when hackers use the version vulnerabilities for the "un-updated" core to hack the website. This information can easily be got from the source in the web browser 

Ben Sibley argues that for the meta tag generator versioning - "serves little purpose, but potentially is/could be used for gathering statistics by identifying sites as using WordPress. Some have said it is a potential security concern because it displays the version of WP you’re using. I’m no security expert, but I’m sure that’s an invalid claim or it wouldn’t be in core since V2.5."

Ref: https://www.competethemes.com/blog/wordpress-meta-tags-ultimate-guide/

I would love a second opinion on this. Thus the comment out in the functions.php file. If this workable, a merge would be good.