### PR TITLE
Remove body class "hfeed" from 404 template

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -20,7 +20,7 @@ function _s_body_classes( $classes ) {
 	}
 
 	// Adds a class of hfeed to non-singular pages.
-	if ( ! is_singular() ) {
+	if ( ! is_singular() && ! is_404() ) {
 		$classes[] = 'hfeed';
 	}
 


### PR DESCRIPTION
The body class name `hfeed` should be only on pages with multiple entry elements, and when news feed may be used I think.