### PR TITLE
Add schema microdata

### DIFF
--- a/404.php
+++ b/404.php
@@ -10,14 +10,14 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main" role="main" itemscope="itemscope" itemprop="mainContentOfPage">
 
 			<section class="error-404 not-found">
 				<header class="page-header">
-					<h1 class="page-title"><?php esc_html_e( 'Oops! That page can&rsquo;t be found.', '_s' ); ?></h1>
+					<h1 class="page-title" itemprop="headline"><?php esc_html_e( 'Oops! That page can&rsquo;t be found.', '_s' ); ?></h1>
 				</header><!-- .page-header -->
 
-				<div class="page-content">
+				<div class="page-content" itemprop="text">
 					<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try one of the links below or a search?', '_s' ); ?></p>
 
 					<?php

--- a/archive.php
+++ b/archive.php
@@ -17,8 +17,8 @@ get_header(); ?>
 
 			<header class="page-header">
 				<?php
-					the_archive_title( '<h1 class="page-title">', '</h1>' );
-					the_archive_description( '<div class="archive-description">', '</div>' );
+					the_archive_title( '<h1 class="page-title" itemprop="headline">', '</h1>' );
+					the_archive_description( '<div class="archive-description" itemprop="description">', '</div>' );
 				?>
 			</header><!-- .page-header -->
 

--- a/footer.php
+++ b/footer.php
@@ -13,7 +13,7 @@
 
 	</div><!-- #content -->
 
-	<footer id="colophon" class="site-footer" role="contentinfo">
+	<footer id="colophon" class="site-footer" role="contentinfo" itemscope="itemscope" itemtype="http://schema.org/WPFooter">
 		<div class="site-info">
 			<a href="<?php echo esc_url( __( 'https://wordpress.org/', '_s' ) ); ?>"><?php printf( esc_html__( 'Proudly powered by %s', '_s' ), 'WordPress' ); ?></a>
 			<span class="sep"> | </span>

--- a/functions.php
+++ b/functions.php
@@ -101,7 +101,7 @@ function _s_widgets_init() {
 }
 add_action( 'widgets_init', '_s_widgets_init' );
 
-/**
+ /**
  * Enqueue scripts and styles.
  */
 function _s_scripts() {

--- a/header.php
+++ b/header.php
@@ -19,30 +19,35 @@
 <?php wp_head(); ?>
 </head>
 
-<body <?php body_class(); ?>>
+<body <?php body_class(); _s_schema_microdata(); ?>>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', '_s' ); ?></a>
 
-	<header id="masthead" class="site-header" role="banner">
-		<div class="site-branding">
+	<header id="masthead" class="site-header" role="banner" itemscope="itemscope" itemtype="http://schema.org/WPHeader">
+		<div class="site-branding" itemscope itemtype="http://schema.org/Organization">
 			<?php
 			if ( is_front_page() && is_home() ) : ?>
-				<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+				<h1 class="site-title" itemprop="name"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="url"><?php bloginfo( 'name' ); ?></a></h1>
 			<?php else : ?>
-				<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+				<p class="site-title" itemprop="name"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="url"><?php bloginfo( 'name' ); ?></a></p>
 			<?php
 			endif;
 
 			$description = get_bloginfo( 'description', 'display' );
 			if ( $description || is_customize_preview() ) : ?>
-				<p class="site-description"><?php echo $description; /* WPCS: xss ok. */ ?></p>
+				<p class="site-description" itemprop="description"><?php echo $description; /* WPCS: xss ok. */ ?></p>
 			<?php
 			endif; ?>
 		</div><!-- .site-branding -->
 
-		<nav id="site-navigation" class="main-navigation" role="navigation">
+		<nav id="site-navigation" class="main-navigation" role="navigation" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement">
 			<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php esc_html_e( 'Primary Menu', '_s' ); ?></button>
-			<?php wp_nav_menu( array( 'theme_location' => 'menu-1', 'menu_id' => 'primary-menu' ) ); ?>
+			<?php wp_nav_menu( array( 
+				'theme_location' => 'menu-1', 
+				'menu_id' => 'primary-menu',
+				'link_before' => '<span itemprop="name">', 
+				'link_after' => '</span>' 
+			) ); ?>
 		</nav><!-- #site-navigation -->
 	</header><!-- #masthead -->
 

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -37,3 +37,54 @@ function _s_pingback_header() {
 	}
 }
 add_action( 'wp_head', '_s_pingback_header' );
+
+
+/**
+ * Adds the correct schema microdata to the body tag
+ * depending on the type of page
+ */
+function _s_schema_microdata() {
+    
+    $schema = 'http://schema.org/';
+
+    if( is_single() ) {
+        $type = "Article";
+    }
+
+    else if( is_home() || ( is_archive() && !is_author() ) ) {
+    	$type = "Blog";
+    }
+
+    else if( is_page( array('contact', 'contact-us', 'contact-page') ) ) {
+        $type = 'ContactPage';
+    }
+
+    else if( is_author() ) {
+        $type = 'ProfilePage';
+    }
+
+    else if( is_search() ) {
+        $type = 'SearchResultsPage';
+    }
+
+    else {
+        $type = 'WebPage';
+    }
+
+    echo 'itemscope="itemscope" itemtype="' . $schema . $type . '"';
+}
+
+/**
+ * Add schema microdata to thumbnails
+ */
+the_post_thumbnail('thumbnail', array('itemprop' => 'image'));
+
+
+/**
+ * Add schema microdata to nav urls
+ */
+function add_menu_atts( $atts, $item, $args ) {
+    $atts['itemprop'] = 'url';
+    return $atts;
+}
+add_filter( 'nav_menu_link_attributes', 'add_menu_atts', 10, 3 );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -12,9 +12,9 @@ if ( ! function_exists( '_s_posted_on' ) ) :
  * Prints HTML with meta information for the current post-date/time and author.
  */
 function _s_posted_on() {
-	$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+	$time_string = '<time class="entry-date published updated" datetime="%1$s" itemprop="datePublished">%2$s</time>';
 	if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-		$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+		$time_string = '<time class="entry-date published" datetime="%1$s" itemprop="datePublished">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
 	}
 
 	$time_string = sprintf( $time_string,
@@ -31,7 +31,7 @@ function _s_posted_on() {
 
 	$byline = sprintf(
 		esc_html_x( 'by %s', 'post author', '_s' ),
-		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+		'<span class="author vcard" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" itemprop="name">' . esc_html( get_the_author() ) . '</a></span>'
 	);
 
 	echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>'; // WPCS: XSS OK.

--- a/index.php
+++ b/index.php
@@ -15,14 +15,14 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main" role="main" itemscope="itemscope" itemprop="mainContentOfPage">
 
 		<?php
 		if ( have_posts() ) :
 
 			if ( is_home() && ! is_front_page() ) : ?>
 				<header>
-					<h1 class="page-title screen-reader-text"><?php single_post_title(); ?></h1>
+					<h1 class="page-title screen-reader-text" itemprop="headline"><?php single_post_title(); ?></h1>
 				</header>
 
 			<?php

--- a/page.php
+++ b/page.php
@@ -15,7 +15,7 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main" role="main" itemscope="itemscope" itemprop="mainContentOfPage">
 
 			<?php
 			while ( have_posts() ) : the_post();

--- a/search.php
+++ b/search.php
@@ -10,13 +10,13 @@
 get_header(); ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main" role="main" itemscope="itemscope" itemprop="mainContentOfPage">
 
 		<?php
 		if ( have_posts() ) : ?>
 
 			<header class="page-header">
-				<h1 class="page-title"><?php printf( esc_html__( 'Search Results for: %s', '_s' ), '<span>' . get_search_query() . '</span>' ); ?></h1>
+				<h1 class="page-title" itemprop="headline"><?php printf( esc_html__( 'Search Results for: %s', '_s' ), '<span>' . get_search_query() . '</span>' ); ?></h1>
 			</header><!-- .page-header -->
 
 			<?php

--- a/sidebar.php
+++ b/sidebar.php
@@ -12,6 +12,6 @@ if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 }
 ?>
 
-<aside id="secondary" class="widget-area" role="complementary">
+<aside id="secondary" class="widget-area" role="complementary" itemscope="itemscope" itemtype="http://schema.org/WPSideBar">
 	<?php dynamic_sidebar( 'sidebar-1' ); ?>
 </aside><!-- #secondary -->

--- a/single.php
+++ b/single.php
@@ -10,7 +10,7 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main" role="main" itemscope="itemscope" itemprop="mainContentOfPage">
 
 		<?php
 		while ( have_posts() ) : the_post();

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -11,10 +11,10 @@
 
 <section class="no-results not-found">
 	<header class="page-header">
-		<h1 class="page-title"><?php esc_html_e( 'Nothing Found', '_s' ); ?></h1>
+		<h1 class="page-title" itemprop="headline"><?php esc_html_e( 'Nothing Found', '_s' ); ?></h1>
 	</header><!-- .page-header -->
 
-	<div class="page-content">
+	<div class="page-content" itemprop="text">
 		<?php
 		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -11,10 +11,10 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
-		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+		<?php the_title( '<h1 class="entry-title" itemprop="headline">', '</h1>' ); ?>
 	</header><!-- .entry-header -->
 
-	<div class="entry-content">
+	<div class="entry-content" itemprop="text">
 		<?php
 			the_content();
 

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -9,11 +9,11 @@
 
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?> itemscope="itemscope" itemtype="http://schema.org/BlogPosting" itemprop="blogPost">
 	<header class="entry-header">
 		<?php
 		if ( is_single() ) :
-			the_title( '<h1 class="entry-title">', '</h1>' );
+			the_title( '<h1 class="entry-title" itemprop="headline">', '</h1>' );
 		else :
 			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 		endif;
@@ -26,7 +26,7 @@
 		endif; ?>
 	</header><!-- .entry-header -->
 
-	<div class="entry-content">
+	<div class="entry-content" itemprop="text">
 		<?php
 			the_content( sprintf(
 				/* translators: %s: Name of current post. */


### PR DESCRIPTION
Added standard WordPress schema microdata. The markup has been tested using the Google Structured Data Testing Tool. https://search.google.com/structured-data/testing-tool/u/0/. Schema Markup is a search engine ranking factor and should be included by default to save developers manually adding it later.



