### PR TITLE
Prevent broken translations in some locales for the edit post link 

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -68,7 +68,7 @@ function _s_entry_footer() {
 
 	edit_post_link(
 		sprintf(
-			/* translators: %s: Name of current post */
+			/* translators: %s: Name of current post. Only visible to screen readers */
 			__( 'Edit <span class="screen-reader-text">%s</span>', '_s' ),
 			get_the_title()
 		),

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -69,7 +69,7 @@ function _s_entry_footer() {
 	edit_post_link(
 		sprintf(
 			/* translators: %s: Name of current post. Only visible to screen readers */
-			__( 'Edit <span class="screen-reader-text">%s</span>', '_s' ),
+			wp_kses( __( 'Edit <span class="screen-reader-text">%s</span>', '_s' ), array( 'span' => array( 'class' => array() ) ) ),
 			get_the_title()
 		),
 		'<span class="edit-link">',

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -69,8 +69,8 @@ function _s_entry_footer() {
 	edit_post_link(
 		sprintf(
 			/* translators: %s: Name of current post */
-			esc_html__( 'Edit %s', '_s' ),
-			the_title( '<span class="screen-reader-text">"', '"</span>', false )
+			__( 'Edit <span class="screen-reader-text">%s</span>', '_s' ),
+			get_the_title()
 		),
 		'<span class="edit-link">',
 		'</span>'

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -31,8 +31,8 @@
 				edit_post_link(
 					sprintf(
 						/* translators: %s: Name of current post */
-						esc_html__( 'Edit %s', '_s' ),
-						the_title( '<span class="screen-reader-text">"', '"</span>', false )
+						__( 'Edit <span class="screen-reader-text">%s</span>', '_s' ),
+						get_the_title()
 					),
 					'<span class="edit-link">',
 					'</span>'

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -31,7 +31,7 @@
 				edit_post_link(
 					sprintf(
 						/* translators: %s: Name of current post. Only visible to screen readers */
-						__( 'Edit <span class="screen-reader-text">%s</span>', '_s' ),
+						wp_kses( __( 'Edit <span class="screen-reader-text">%s</span>', '_s' ), array( 'span' => array( 'class' => array() ) ) ),
 						get_the_title()
 					),
 					'<span class="edit-link">',

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -30,7 +30,7 @@
 			<?php
 				edit_post_link(
 					sprintf(
-						/* translators: %s: Name of current post */
+						/* translators: %s: Name of current post. Only visible to screen readers */
 						__( 'Edit <span class="screen-reader-text">%s</span>', '_s' ),
 						get_the_title()
 					),


### PR DESCRIPTION
Since #775, the translation of the _edit post link_ in some languages can end up forming a partial sentence.

By default, in English, the visual output is the word "**Edit**".
In Hebrew for example, the translation would be a single word:
<pre><p dir='rtl' align='right'>לערוך</p></pre>

With the addition of the post title, the translator is instructed to translate `Edit %s` with `%s` being the post name. In Hebrew, the translation will be
<pre><p dir='rtl' align='right'>לערוך את %s</p></pre>
Note the added word `את`

To quote from [this post](https://myhebrewwords.wordpress.com/2014/03/07/1-%D7%90%D7%AA-et-the-most-common-word-in-the-hebrew-language/):

> The word **את** comes before a definite object. It has no equivalent in the English language.

The end visual result in Hebrew would be:
<pre><p dir='rtl' align='right'>לערוך את</p></pre>

Which is weird. Think of it as "Edit The" (without the actual object).

This PR fixes that by expanding the comment to note that the post name only visible to screen readers, and puts the screen reader span html inside the translated string.
The translator for Hebrew can now do something like
`לערוך <span class="screen-reader-text">את %s</span>`, putting the את word inside the invisible span.



