### PR TITLE
Matching style.css

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,4 @@ Want to have your avatar listed as one of the `_s` contributors [here](http://un
 * [@obenland](https://github.com/obenland)
 * [@ianstewart](https://github.com/ianstewart)
 * [@mfields](https://github.com/mfields)
+* [@philiparthurmoore](https://github.com/philiparthurmoore)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,7 @@ Want to have your avatar listed as one of the `_s` contributors [here](http://un
 * [@sixhours](https://github.com/sixhours) 
 * [@laurelfulford](https://github.com/laurelfulford)
 * [@alaczek](https://github.com/alaczek)
+* [@lancewillett](https://github.com/lancewillett)
+* [@obenland](https://github.com/obenland)
+* [@ianstewart](https://github.com/ianstewart)
+* [@mfields](https://github.com/mfields)

--- a/sass/modules/_accessibility.scss
+++ b/sass/modules/_accessibility.scss
@@ -5,6 +5,7 @@
 	height: 1px;
 	width: 1px;
 	overflow: hidden;
+	word-wrap: normal !important;
 
 	&:focus {
 		background-color: $color__background-screen;

--- a/sass/modules/_accessibility.scss
+++ b/sass/modules/_accessibility.scss
@@ -5,8 +5,8 @@
 	height: 1px;
 	width: 1px;
 	overflow: hidden;
-	word-wrap: normal !important;
-
+	word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+	
 	&:focus {
 		background-color: $color__background-screen;
 		border-radius: 3px;

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -6,7 +6,7 @@ Author URI: http://automattic.com/
 Description: Hi. I'm a starter theme called <code>_s</code>, or <em>underscores</em>, if you like. I'm a theme meant for hacking so don't use me as a <em>Parent Theme</em>. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.
 Version: 1.0.0
 License: GNU General Public License v2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+License URI: LICENSE
 Text Domain: _s
 Tags:
 


### PR DESCRIPTION
Adding word-wrap to .screen-reader-text
* Many screen reader and browser combinations announce broken words as they would appear visually.