### PR TITLE
doctype uppercase to lowercase

### DIFF
--- a/header.php
+++ b/header.php
@@ -9,7 +9,7 @@
  * @package _s
  */
 
-?><!DOCTYPE html>
+?><!doctype html>
 <html <?php language_attributes(); ?>>
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">


### PR DESCRIPTION
it doesn't really matter, but for consistency doctype can be in lowercase. besides html5boilerplate is also changed to lowercase
 