### PR TITLE
Code obfuscation: Fix assignment within a condition

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -84,7 +84,8 @@ endif;
  * @return bool
  */
 function _s_categorized_blog() {
-	if ( false === ( $all_the_cool_cats = get_transient( '_s_categories' ) ) ) {
+	$all_the_cool_cats = get_transient( '_s_categories' );
+	if ( false === $all_the_cool_cats ) {
 		// Create an array of all the categories that are attached to posts.
 		$all_the_cool_cats = get_categories( array(
 			'fields'     => 'ids',


### PR DESCRIPTION
Assigning to a variable within a condition makes for harder to debug code. WPCS now checks for this as well.

This commit fixes the one instance in `_s` where this was happening.