### PR TITLE
I18n: Fix a translation call for a text string which needs context

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -53,7 +53,7 @@ function _s_entry_footer() {
 		}
 
 		/* translators: used between list items, there is a space after the comma */
-		$tags_list = get_the_tag_list( '', esc_html__( ', ', '_s' ) );
+		$tags_list = get_the_tag_list( '', esc_html_x( ', ', 'list item separator', '_s' ) );
 		if ( $tags_list ) {
 			printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', '_s' ) . '</span>', $tags_list ); // WPCS: XSS OK.
 		}


### PR DESCRIPTION
When a translation context is unclear and the translation might be affacted by it, `_x()` rather than `__()` should be used and a translation context should be provided.

Ref: https://developer.wordpress.org/reference/functions/esc_html_x/

This PR fixes one such translation call within `_s`.