### PR TITLE
I18n and code layout

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -15,9 +15,15 @@
 
 	<footer id="colophon" class="site-footer" role="contentinfo">
 		<div class="site-info">
-			<a href="<?php echo esc_url( __( 'https://wordpress.org/', '_s' ) ); ?>"><?php printf( esc_html__( 'Proudly powered by %s', '_s' ), 'WordPress' ); ?></a>
+			<a href="<?php echo esc_url( __( 'https://wordpress.org/', '_s' ) ); ?>"><?php
+				/* translators: %s: CMS name, i.e. WordPress. */
+				printf( esc_html__( 'Proudly powered by %s', '_s' ), 'WordPress' );
+			?></a>
 			<span class="sep"> | </span>
-			<?php printf( esc_html__( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="https://automattic.com/" rel="designer">Automattic</a>' ); ?>
+			<?php
+				/* translators: 1: Theme name, 2: Theme author. */
+				printf( esc_html__( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="https://automattic.com/" rel="designer">Automattic</a>' );
+			?>
 		</div><!-- .site-info -->
 	</footer><!-- #colophon -->
 </div><!-- #page -->

--- a/header.php
+++ b/header.php
@@ -42,7 +42,12 @@
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">
 			<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php esc_html_e( 'Primary Menu', '_s' ); ?></button>
-			<?php wp_nav_menu( array( 'theme_location' => 'menu-1', 'menu_id' => 'primary-menu' ) ); ?>
+			<?php
+				wp_nav_menu( array(
+					'theme_location' => 'menu-1',
+					'menu_id'        => 'primary-menu',
+				) );
+			?>
 		</nav><!-- #site-navigation -->
 	</header><!-- #masthead -->
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -25,11 +25,13 @@ function _s_posted_on() {
 	);
 
 	$posted_on = sprintf(
+		/* translators: %s: post date. */
 		esc_html_x( 'Posted on %s', 'post date', '_s' ),
 		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
 	);
 
 	$byline = sprintf(
+		/* translators: %s: post author. */
 		esc_html_x( 'by %s', 'post author', '_s' ),
 		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
 	);
@@ -49,12 +51,14 @@ function _s_entry_footer() {
 		/* translators: used between list items, there is a space after the comma */
 		$categories_list = get_the_category_list( esc_html__( ', ', '_s' ) );
 		if ( $categories_list && _s_categorized_blog() ) {
+			/* translators: 1: list of categories. */
 			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', '_s' ) . '</span>', $categories_list ); // WPCS: XSS OK.
 		}
 
 		/* translators: used between list items, there is a space after the comma */
 		$tags_list = get_the_tag_list( '', esc_html__( ', ', '_s' ) );
 		if ( $tags_list ) {
+			/* translators: 1: list of tags. */
 			printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', '_s' ) . '</span>', $tags_list ); // WPCS: XSS OK.
 		}
 	}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -65,8 +65,20 @@ function _s_entry_footer() {
 
 	if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
 		echo '<span class="comments-link">';
-		/* translators: %s: post title */
-		comments_popup_link( sprintf( wp_kses( __( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', '_s' ), array( 'span' => array( 'class' => array() ) ) ), get_the_title() ) );
+		comments_popup_link(
+			sprintf(
+				wp_kses(
+					/* translators: %s: post title */
+					__( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', '_s' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
+				get_the_title()
+			)
+		);
 		echo '</span>';
 	}
 

--- a/search.php
+++ b/search.php
@@ -16,7 +16,10 @@ get_header(); ?>
 		if ( have_posts() ) : ?>
 
 			<header class="page-header">
-				<h1 class="page-title"><?php printf( esc_html__( 'Search Results for: %s', '_s' ), '<span>' . get_search_query() . '</span>' ); ?></h1>
+				<h1 class="page-title"><?php
+					/* translators: %s: search query. */
+					printf( esc_html__( 'Search Results for: %s', '_s' ), '<span>' . get_search_query() . '</span>' );
+				?></h1>
 			</header><!-- .page-header -->
 
 			<?php

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -18,7 +18,10 @@
 		<?php
 		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-			<p><?php printf( wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', '_s' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
+			<p><?php
+				/* translators: 1: link to WP admin new post page. */
+				printf( wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', '_s' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'post-new.php' ) ) );
+			?></p>
 
 		<?php elseif ( is_search() ) : ?>
 

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -19,8 +19,18 @@
 		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
 			<p><?php
-				/* translators: 1: link to WP admin new post page. */
-				printf( wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', '_s' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'post-new.php' ) ) );
+				printf(
+					wp_kses(
+						/* translators: 1: link to WP admin new post page. */
+						__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', '_s' ),
+						array(
+							'a' => array(
+								'href' => array(),
+							),
+						)
+					),
+					esc_url( admin_url( 'post-new.php' ) )
+				);
 			?></p>
 
 		<?php elseif ( is_search() ) : ?>

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -29,8 +29,15 @@
 	<div class="entry-content">
 		<?php
 			the_content( sprintf(
-				/* translators: %s: Name of current post. */
-				wp_kses( __( 'Continue reading %s <span class="meta-nav">&rarr;</span>', '_s' ), array( 'span' => array( 'class' => array() ) ) ),
+				wp_kses(
+					/* translators: %s: Name of current post. */
+					__( 'Continue reading %s <span class="meta-nav">&rarr;</span>', '_s' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
 				the_title( '<span class="screen-reader-text">"', '"</span>', false )
 			) );
 


### PR DESCRIPTION
This PR addresses two separate issues, but is pulled as one as the fixes would otherwise cause merge conflicts.

#### Commit 1:
Fixes missing `/* translators */` comments for translatable text strings containing placeholders.

#### Commit 2:
Fixes infractions against the `For associative arrays, values should start on a new line.` code style rule and changes the code layout of the nested functions where this occurred for optimal readability.

Ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation