### PR TITLE
PHPCS ruleset: Improve documentation links

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress Theme Coding Standards">
 	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
-	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki -->
 
 	<!-- Set a description for this ruleset. -->
 	<description>A custom set of code standard rules to check for WordPress themes.</description>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,6 +3,7 @@
 	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
 	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki -->
+	<!-- See https://github.com/wimg/PHPCompatibility -->
 
 	<!-- Set a description for this ruleset. -->
 	<description>A custom set of code standard rules to check for WordPress themes.</description>


### PR DESCRIPTION
#### Fix link to WPCS in the PHPCS ruleset.

The link was pointing to the `WordPress-Core` ruleset, while `_s` uses the `WordPress` ruleset which encompasses more than just the core rules.

Pointing to the repo + the wiki homepage will give people a better starting point.

#### Add link to the PHPCompatibility repo.

At the top of the ruleset there were links to the PHPCS and the WPCS repo, but not to the PHPCompatibility repo which is also being used.