### PR TITLE
WPCS: Allow for typical theme specific file names based on the theme hierarchy

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,6 +36,14 @@
 		</properties>
 	</rule>
 
+	<!-- Allow for theme specific exceptions to the file name rules based
+		 on the theme hierarchy. -->
+	<rule ref="WordPress.Files.FileName">
+		<properties>
+			<property name="is_theme" value="true" />
+		</properties>
+	</rule>
+
 	<!-- Include sniffs for PHP cross-version compatibility. -->
 	<config name="testVersion" value="5.2-99.0"/>
 	<rule ref="PHPCompatibility"/>


### PR DESCRIPTION
WPCS checks that words in file names are separated by dashes, not underscores.

For themes, a number of exceptions are made to this rule, to allow for `taxonomy-{$taxo_nomy}.php` and `archive-{$post_type}.php` type of file names.

While `_s` itself currently does not contain any files which would require the exception, it is likely that derivative themes will have these kind of files.
Setting the property in the PHPCS ruleset used for `_s` will thereby give a good example of how this should be handled (and prevent people from excluding the sniff completely).

Refs:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#themes-allow-filename-exceptions
* https://developer.wordpress.org/themes/basics/template-hierarchy/
* http://wphierarchy.com/