### PR TITLE
Add `optgroup` in typography

### DIFF
--- a/sass/typography/_typography.scss
+++ b/sass/typography/_typography.scss
@@ -2,6 +2,7 @@ body,
 button,
 input,
 select,
+optgroup,
 textarea {
 	color: $color__text-main;
 	font-family: $font__main;

--- a/style.css
+++ b/style.css
@@ -264,6 +264,7 @@ body,
 button,
 input,
 select,
+optgroup,
 textarea {
 	color: #404040;
 	font-family: sans-serif;


### PR DESCRIPTION
Closes #1068 
This PR adds `optgroup` in #Typography ( via both `_typography.scss` & `style.css` ). It fixes the odd styling of the `select` element. 