### PR TITLE
WPCS: Verify that no deprecated or removed WP functions are being used.

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -45,6 +45,15 @@
 		</properties>
 	</rule>
 
+	<!-- Verify that no WP functions are used which are deprecated or have been removed.
+		 The minimum version set here should be in line with the minimum WP version
+		 as set in the "Requires at least" tag in the readme.txt file. -->
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="4.0" />
+		</properties>
+	</rule>
+
 	<!-- Include sniffs for PHP cross-version compatibility. -->
 	<config name="testVersion" value="5.2-99.0"/>
 	<rule ref="PHPCompatibility"/>


### PR DESCRIPTION
Since WPCS 0.11.0, it is possible to check that no WP deprecated functions are used.

By default, the minimum wp version against which this is checked is 3 versions before the current release (would be 4.5 now as 4.8 is out), however, the minimum wp version used is configurable and should by rights be in line with the minimum WP version for the theme as proclaimed in the `readme.txt` file.
This minor change sorts that out as well as informs theme-devs about this feature.

Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-and-function-parameters