### PR TITLE
Add editor-style.css to educate themers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Here are some tips to consider and to help you write a great report:
 * `_s` supports Microsoft Internet Explorer 11 and Edge, as well as the latest two versions of all other major browsers.
 * `_s` is backwards compatible with the two versions prior to the current stable version of WordPress.
 * `_s` uses HTML5 markup.
-* We decided not to include translations [[#50](https://github.com/Automattic/_s/pull/50)] beyond the existing `_s.pot` file, a RTL stylesheet [[#263](https://github.com/Automattic/_s/pull/263)], or editor styles [[#225](https://github.com/Automattic/_s/pull/225)], as they are likely to change during development of an `_s` based theme.
+* We decided not to include translations [[#50](https://github.com/Automattic/_s/pull/50)] beyond the existing `_s.pot` file, RTL CSS styles [[#263](https://github.com/Automattic/_s/pull/263)], or editor CSS styles [[#1019](https://github.com/Automattic/_s/issues/1019)], as they are likely to change during development of an `_s` based theme.
 
 ## Contributing code
 

--- a/editor-style.css
+++ b/editor-style.css
@@ -1,0 +1,23 @@
+/*
+Styling the WordPress text editor contents to match the theme improves the user experience.
+Including these styles show editors how their text will look without having to preview it.
+
+This file is loaded in functions.php with add_editor_style().
+
+https://codex.wordpress.org/Editor_Style
+*/
+
+/*
+body {
+	box-sizing: border-box;
+	max-width: 640px;
+	margin: 25px auto;
+	padding: 0 20px;
+
+	color: #404040;
+	font-family: sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	line-height: 1.5;
+}
+*/

--- a/functions.php
+++ b/functions.php
@@ -65,6 +65,14 @@ function _s_setup() {
 		'default-image' => '',
 	) ) );
 
+	/*
+	 * Load the editor-style.css file.
+	 * Put CSS for text editor in editor-style.css.
+	 * 
+	 * @link https://developer.wordpress.org/reference/functions/add_editor_style/
+	 */
+	add_editor_style();
+
 	// Add theme support for selective refresh for widgets.
 	add_theme_support( 'customize-selective-refresh-widgets' );
 }

--- a/index.php
+++ b/index.php
@@ -53,4 +53,4 @@ get_header(); ?>
 
 <?php
 get_sidebar();
-get_footer('blog');
+get_footer();

--- a/index.php
+++ b/index.php
@@ -53,4 +53,4 @@ get_header(); ?>
 
 <?php
 get_sidebar();
-get_footer();
+get_footer('blog');

--- a/sass/editor-style.scss
+++ b/sass/editor-style.scss
@@ -1,0 +1,67 @@
+/*
+Styling the WordPress text editor contents to match the theme improves the user experience.
+Including these styles show editors how their text will look without having to preview it.
+
+This file is loaded in functions.php with add_editor_style(). (Assumes editor-style.css is in theme root directory alongside style.css.)
+
+https://codex.wordpress.org/Editor_Style
+*/
+
+/*--------------------------------------------------------------
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+# Normalize
+# Elements
+# Typography
+# Navigation
+    ## Links
+# Alignments
+# Media
+    ## Captions
+    ## Galleries
+# Custom Editor-only Styles
+--------------------------------------------------------------*/
+@import "variables-site/variables-site";
+@import "mixins/mixins-master";
+
+/*--------------------------------------------------------------
+# Normalize
+--------------------------------------------------------------*/
+@import "normalize";
+
+/*--------------------------------------------------------------
+# Elements
+--------------------------------------------------------------*/
+@import "elements/elements";
+
+/*--------------------------------------------------------------
+# Typography
+--------------------------------------------------------------*/
+@import "typography/typography";
+
+/*--------------------------------------------------------------
+# Navigation
+--------------------------------------------------------------*/
+@import "navigation/links";
+
+/*--------------------------------------------------------------
+# Alignments
+--------------------------------------------------------------*/
+@import "modules/alignments";
+
+/*--------------------------------------------------------------
+# Media
+--------------------------------------------------------------*/
+@import "media/media";
+
+/*--------------------------------------------------------------
+# Custom Editor Styles
+--------------------------------------------------------------*/
+/*
+body {
+	box-sizing: border-box;
+	max-width: 640px; // match content width
+	margin: 25px auto;
+	padding: 0 20px;
+}
+*/


### PR DESCRIPTION
First pass on a PR for #1019. It does the following:

- Adds `editor-style.css` and `editor-style.scss`
- Loads the styles in `functions.php`
- Updates `CONTRIBUTING.md` to reflect these changes

#1019 has a long discussion on the best `_s`-appropriate approach to editor styles, and this PR is my attempt at the most robust version of that. In short, the changes introduce:

- no new CSS rules to manage (not including `@import`s which generate styles but don't require additional maintenance barring a major project-wide refactor),
- a solution similar to the existing `rtl.css` file, and
- educational comments with links to relevant reading.

The goal is to educate developers on the benefits of editor styles and not let people forget them in a way that is efficient but doesn't dictate the styles themselves.

Props to @josephfusco for the starting point to the SCSS file.