### PR TITLE
_s: Add basic support for Content Options Post Details

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -27,14 +27,14 @@ function _s_jetpack_setup() {
 
 	// Add theme support for Content Options.
 	add_theme_support( 'jetpack-content-options', array(
-	    'post-details'       => array(
-	        'stylesheet'      => '_s-style',
-	        'date'            => '.posted-on',
-	        'categories'      => '.cat-links',
-	        'tags'            => '.tags-links',
-	        'author'          => '.byline',
-	        'comment'         => '.comments-link',
-	    ),
+		'post-details'       => array(
+			'stylesheet'      => '_s-style',
+			'date'            => '.posted-on',
+			'categories'      => '.cat-links',
+			'tags'            => '.tags-links',
+			'author'          => '.byline',
+			'comment'         => '.comments-link',
+			),
 	) );
 }
 add_action( 'after_setup_theme', '_s_jetpack_setup' );

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -12,6 +12,7 @@
  *
  * See: https://jetpack.com/support/infinite-scroll/
  * See: https://jetpack.com/support/responsive-videos/
+ * See: https://jetpack.com/support/content-options/
  */
 function _s_jetpack_setup() {
 	// Add theme support for Infinite Scroll.
@@ -23,6 +24,18 @@ function _s_jetpack_setup() {
 
 	// Add theme support for Responsive Videos.
 	add_theme_support( 'jetpack-responsive-videos' );
+
+	// Add theme support for Content Options.
+	add_theme_support( 'jetpack-content-options', array(
+	    'post-details'       => array(
+	        'stylesheet'      => '_s-style',
+	        'date'            => '.posted-on',
+	        'categories'      => '.cat-links',
+	        'tags'            => '.tags-links',
+	        'author'          => '.byline',
+	        'comment'         => '.comments-link',
+	    ),
+	) );
 }
 add_action( 'after_setup_theme', '_s_jetpack_setup' );
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -12,11 +12,6 @@
  * @return array
  */
 function _s_body_classes( $classes ) {
-	// Adds a class of group-blog to blogs with more than 1 published author.
-	if ( is_multi_author() ) {
-		$classes[] = 'group-blog';
-	}
-
 	// Adds a class of hfeed to non-singular pages.
 	if ( ! is_singular() ) {
 		$classes[] = 'hfeed';

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -50,7 +50,7 @@ function _s_entry_footer() {
 	if ( 'post' === get_post_type() ) {
 		/* translators: used between list items, there is a space after the comma */
 		$categories_list = get_the_category_list( esc_html__( ', ', '_s' ) );
-		if ( $categories_list && _s_categorized_blog() ) {
+		if ( $categories_list ) {
 			/* translators: 1: list of categories. */
 			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', '_s' ) . '</span>', $categories_list ); // WPCS: XSS OK.
 		}
@@ -100,47 +100,3 @@ function _s_entry_footer() {
 	);
 }
 endif;
-
-/**
- * Returns true if a blog has more than 1 category.
- *
- * @return bool
- */
-function _s_categorized_blog() {
-	$all_the_cool_cats = get_transient( '_s_categories' );
-	if ( false === $all_the_cool_cats ) {
-		// Create an array of all the categories that are attached to posts.
-		$all_the_cool_cats = get_categories( array(
-			'fields'     => 'ids',
-			'hide_empty' => 1,
-			// We only need to know if there is more than one category.
-			'number'     => 2,
-		) );
-
-		// Count the number of categories that are attached to the posts.
-		$all_the_cool_cats = count( $all_the_cool_cats );
-
-		set_transient( '_s_categories', $all_the_cool_cats );
-	}
-
-	if ( $all_the_cool_cats > 1 || is_preview() ) {
-		// This blog has more than 1 category so _s_categorized_blog should return true.
-		return true;
-	} else {
-		// This blog has only 1 category so _s_categorized_blog should return false.
-		return false;
-	}
-}
-
-/**
- * Flush out the transients used in _s_categorized_blog.
- */
-function _s_category_transient_flusher() {
-	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-		return;
-	}
-	// Like, beat it. Dig?
-	delete_transient( '_s_categories' );
-}
-add_action( 'edit_category', '_s_category_transient_flusher' );
-add_action( 'save_post',     '_s_category_transient_flusher' );

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -6,14 +6,8 @@
 	margin: 0 0 1.5em;
 }
 
-.byline,
 .updated:not(.published){
 	display: none;
-}
-
-.single .byline,
-.group-blog .byline {
-	display: inline;
 }
 
 .page-content,

--- a/style.css
+++ b/style.css
@@ -758,14 +758,8 @@ a:active {
 	margin: 0 0 1.5em;
 }
 
-.byline,
 .updated:not(.published) {
 	display: none;
-}
-
-.single .byline,
-.group-blog .byline {
-	display: inline;
 }
 
 .page-content,


### PR DESCRIPTION
This allows us to always display the category and author since it can
be hidden via Customizer -> Content Options

We don’t need to check for `is_multi_author` or `_s_categorized_blog()`
anymore