### PR TITLE
Loop for gallery-columns should be outside gallery-item braces

### DIFF
--- a/sass/media/_galleries.scss
+++ b/sass/media/_galleries.scss
@@ -10,7 +10,7 @@
 
 	// Loops to enumerate the classes for gallery columns.
 	@for $i from 2 through 9 {
-		.gallery-columns-#{$i} {
+		.gallery-columns-#{$i} & {
 			max-width: ( 100% / $i );
 		}
 	}


### PR DESCRIPTION
The compilation gives 
.gallery-item .gallery-columns-X  { ... }
but we need
.gallery-columns-X .gallery-item { ... }

The problem doesn't exist in style.css file in the repository