### PR TITLE
Avoide using HTML tags in translation strings

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -67,15 +67,9 @@ function _s_entry_footer() {
 		echo '<span class="comments-link">';
 		comments_popup_link(
 			sprintf(
-				wp_kses(
-					/* translators: %s: post title */
-					__( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', '_s' ),
-					array(
-						'span' => array(
-							'class' => array(),
-						),
-					)
-				),
+				'%1$s <span class="screen-reader-text">%2$s %3$s</span>',
+				__( 'Leave a Comment', '_s' ),
+				__( 'on', '_s' ),
 				get_the_title()
 			)
 		);
@@ -84,15 +78,8 @@ function _s_entry_footer() {
 
 	edit_post_link(
 		sprintf(
-			wp_kses(
-				/* translators: %s: Name of current post. Only visible to screen readers */
-				__( 'Edit <span class="screen-reader-text">%s</span>', '_s' ),
-				array(
-					'span' => array(
-						'class' => array(),
-					),
-				)
-			),
+			'%1$s <span class="screen-reader-text">%2$s</span>',
+			__( 'Edit', '_s' ),
 			get_the_title()
 		),
 		'<span class="edit-link">',

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -20,15 +20,9 @@
 
 			<p><?php
 				printf(
-					wp_kses(
-						/* translators: 1: link to WP admin new post page. */
-						__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', '_s' ),
-						array(
-							'a' => array(
-								'href' => array(),
-							),
-						)
-					),
+					'%1$s <a href="%2$s">%3$s</a>.',
+					__( 'Ready to publish your first post?', '_s' ),
+					__( 'Get started here', '_s' ),
 					esc_url( admin_url( 'post-new.php' ) )
 				);
 			?></p>

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -29,15 +29,8 @@
 	<div class="entry-content">
 		<?php
 			the_content( sprintf(
-				wp_kses(
-					/* translators: %s: Name of current post. Only visible to screen readers */
-					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', '_s' ),
-					array(
-						'span' => array(
-							'class' => array(),
-						),
-					)
-				),
+				'%1$s <span class="screen-reader-text">"%2$s"</span>',
+				__( 'Continue reading', '_s' ),
 				get_the_title()
 			) );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Making translation strings simpler by removing  HTML tags inside them. The translator's comments were also removed, since they are necessary only if `%s` placeholders are used.

#### Related issue(s): https://github.com/Automattic/_s/issues/1175