### PR TITLE
Travis: Use Ubuntu Trusty by default and Precise for PHP 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@
 # @link http://docs.travis-ci.com/user/migrating-from-legacy/#Why-migrate-to-container-based-infrastructure%3F
 # @link http://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure
 sudo: false
+dist: trusty
 
 # Declare project language.
 # @link http://about.travis-ci.org/docs/user/languages/php/
@@ -22,6 +23,7 @@ matrix:
         # Current $required_php_version for WordPress: 5.2.4
         # aliased to 5.2.17
         - php: '5.2'
+          dist: precise
         # aliased to a recent 5.6.x version
         - php: '5.6'
           env: SNIFF=1


### PR DESCRIPTION
Via [#41292](https://core.trac.wordpress.org/ticket/41292)/[r41072](https://core.trac.wordpress.org/changeset/41072)

Starting July 18th 2017, Travis will begin switching the default image to Ubuntu Trusty, which does not support PHP 5.2 or 5.3.

https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

WordPress Core have just committed the above change just now via 

This is not a full fix, because Travis will be dropping precise support entirely in September which will mean we can't run tests on PHP 5.2. I will open an issue where we can track the progress in WordPress Core.