### PR TITLE
WPCS: Update the custom PHPCS ruleset for the release of WPCS 0.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
     # Install CodeSniffer for WordPress Coding Standards checks.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b 2.9.1 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
     # Install WordPress Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b 0.11.0 --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b 0.12.0 --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
     # Install PHP Compatibility sniffs.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b 7.1.5 --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
     # Set install path for PHPCS sniffs.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -37,6 +37,14 @@
 		</properties>
 	</rule>
 
+	<!-- Verify that everything in the global namespace is prefixed with a theme specific prefix.
+		 Multiple valid prefixes can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="_s" />
+		</properties>
+	</rule>
+
 	<!-- Allow for theme specific exceptions to the file name rules based
 		 on the theme hierarchy. -->
 	<rule ref="WordPress.Files.FileName">
@@ -45,10 +53,28 @@
 		</properties>
 	</rule>
 
+	<!-- Verify that no WP classes are used which are deprecated or have been removed.
+		 The minimum version set here should be in line with the minimum WP version
+		 as set in the "Requires at least" tag in the readme.txt file. -->
+	<rule ref="WordPress.WP.DeprecatedClasses">
+		<properties>
+			<property name="minimum_supported_version" value="4.0" />
+		</properties>
+	</rule>
+
 	<!-- Verify that no WP functions are used which are deprecated or have been removed.
 		 The minimum version set here should be in line with the minimum WP version
 		 as set in the "Requires at least" tag in the readme.txt file. -->
 	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="4.0" />
+		</properties>
+	</rule>
+
+	<!-- Verify that no WP function parameters are used which are deprecated or have been removed.
+		 The minimum version set here should be in line with the minimum WP version
+		 as set in the "Requires at least" tag in the readme.txt file. -->
+	<rule ref="WordPress.WP.DeprecatedParameters">
 		<properties>
 			<property name="minimum_supported_version" value="4.0" />
 		</properties>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,7 +26,6 @@
 	<rule ref="WordPress">
 		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
 		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
-		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
 	</rule>
 
 	<!-- Verify that the text_domain is set to the desired text-domain.
@@ -38,12 +37,18 @@
 	</rule>
 
 	<!-- Verify that everything in the global namespace is prefixed with a theme specific prefix.
-		 Multiple valid prefixes can be provided as a comma-delimited list. -->
+		 Multiple valid prefixes can be provided as a comma-delimited list.
+
+		 Temporarily disabled in anticipation of WPCS issue #1043 being fixed.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1043
+	-->
+	<!--
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array" value="_s" />
 		</properties>
 	</rule>
+	-->
 
 	<!-- Allow for theme specific exceptions to the file name rules based
 		 on the theme hierarchy. -->


### PR DESCRIPTION
* Verify that everything in the global namespace is prefixed with a theme prefix.
* Verify that no deprecated or removed WP classes are being used.
* Verify that no deprecated or removed WP function parameters are being used.

The build for this PR will not pass until a number of issues are addressed. This is being handled in a separate PR #1157