### PR TITLE
WIP: Enable coding standards for JS files

### DIFF
--- a/js/customizer.js
+++ b/js/customizer.js
@@ -1,9 +1,9 @@
 /**
- * File customizer.js.
+ * Theme Customizer enhancements for a better user experience. Contains
+ * handlers to make Theme Customizer preview reload changes asynchronously.
  *
- * Theme Customizer enhancements for a better user experience.
- *
- * Contains handlers to make Theme Customizer preview reload changes asynchronously.
+ * @requires customize-preview.js
+ * @package _s
  */
 
 ( function( $ ) {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1,9 +1,10 @@
 /**
- * File navigation.js.
- *
  * Handles toggling the navigation menu for small screens and enables TAB key
  * navigation support for dropdown menus.
+ *
+ * @package _s
  */
+
 ( function() {
 	var container, button, menu, links, i, len;
 
@@ -86,7 +87,7 @@
 
 				if ( ! menuItem.classList.contains( 'focus' ) ) {
 					e.preventDefault();
-					for ( i = 0; i < menuItem.parentNode.children.length; ++i ) {
+					for ( var i = 0, len = menuItem.parentNode.children.length; i < len; ++i ) {
 						if ( menuItem === menuItem.parentNode.children[i] ) {
 							continue;
 						}
@@ -98,7 +99,7 @@
 				}
 			};
 
-			for ( i = 0; i < parentLink.length; ++i ) {
+			for ( var i = 0, len = parentLink.length; i < len; ++i ) {
 				parentLink[i].addEventListener( 'touchstart', touchStartFn, false );
 			}
 		}

--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -1,10 +1,11 @@
 /**
- * File skip-link-focus-fix.js.
- *
  * Helps with accessibility for keyboard only users.
  *
- * Learn more: https://git.io/vWdr2
+ * @link https://git.io/vWdr2
+ *
+ * @package _s
  */
+
 ( function() {
 	var isIe = /(trident|msie)/i.test( navigator.userAgent );
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,7 +17,7 @@
 	<arg value="psvn"/>
 
 	<!-- Only check the PHP files. JS files are checked separately with JSCS and JSHint. -->
-	<arg name="extensions" value="php"/>
+	<arg name="extensions" value="php,js"/>
 
 	<!-- Check all files in this directory and the directories below it. -->
 	<file>.</file>


### PR DESCRIPTION
When discussing in #1153 about activating PHPCS for JavaScript files we realized that there were a few issues to be fixed. This PR does that.

- Enable PHPCS for JS files
- Updated file headers to match the WP coding standards See: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/#file-headers
- Save the length in the loop as a variable. See: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#iteration

We should merge #1140 and #1153 before this.