### PR TITLE
Add numeric pagination support

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -35,7 +35,6 @@ get_header(); ?>
 
 			endwhile;
 
-			// Previous/next post navigation.
 			_s_paging_nav();
 
 		else :

--- a/archive.php
+++ b/archive.php
@@ -35,7 +35,7 @@ get_header(); ?>
 
 			endwhile;
 
-			// Echo archive pagination in page numbers format.
+			// Previous/next post navigation.
 			_s_paging_nav();
 
 		else :

--- a/archive.php
+++ b/archive.php
@@ -35,7 +35,7 @@ get_header(); ?>
 
 			endwhile;
 
-			// Previous/next post navigation.
+			// Echo archive pagination in page numbers format.
 			_s_paging_nav();
 
 		else :

--- a/archive.php
+++ b/archive.php
@@ -35,7 +35,8 @@ get_header(); ?>
 
 			endwhile;
 
-			the_posts_navigation();
+			// Previous/next post navigation.
+			_s_paging_nav();
 
 		else :
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -20,8 +20,8 @@ if ( ! function_exists( '_s_paging_nav' ) ) :
 		$args = wp_parse_args( $args, array(
 			'end_size' => 2,
 			'mid_size' => 2,
-			'prev_text' => __( '&#171 Previous page', '_s' ),
-			'next_text' => __( 'Next page &#187', '_s' ),
+			'prev_text' => __( '← Previous page', '_s' ),
+			'next_text' => __( 'Next page →', '_s' ),
 			'before_page_number' => '<span class="screen-reader-text">' . __( 'Page', '_s' ) . ' </span>',
 		) );
 		the_posts_pagination( $args );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -54,7 +54,20 @@ if ( ! function_exists( '_s_paging_nav' ) ) :
 		<nav class="navigation paging-navigation" role="navigation">
 			<h1 class="screen-reader-text"><?php esc_html_e( 'Posts navigation', '_s' ); ?></h1>
 			<div class="pagination loop-pagination">
-				<?php echo esc_html( $links ); ?>
+
+				<?php
+				echo wp_kses(
+					$links,
+					array(
+						'a' => array(
+							'href' => array(),
+							'class' => array(),
+						),
+						'span' => array(),
+					)
+				);
+				?>
+
 			</div><!-- .pagination -->
 		</nav><!-- .navigation -->
 		<?php

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -9,70 +9,22 @@
 
 if ( ! function_exists( '_s_paging_nav' ) ) :
 	/**
-	 * Echo archive pagination in page numbers format.
+	 * Displays a paginated navigation to next/previous set of posts, when applicable.
 	 *
 	 * This is shown at the end of archives to get to another page of entries.
+	 *
+	 * @param array $args Optional. See the_posts_pagination() for available arguments.
+	 * @link https://developer.wordpress.org/reference/functions/the_posts_pagination/#parameters
 	 */
-	function _s_paging_nav() {
-		global $wp_query, $wp_rewrite;
-
-		// Don't print empty markup if there's only one page.
-		if ( $wp_query->max_num_pages < 2 ) {
-			return;
-		}
-
-		$paged        = get_query_var( 'paged' ) ? intval( get_query_var( 'paged' ) ) : 1;
-		$pagenum_link = html_entity_decode( get_pagenum_link() );
-		$query_args   = array();
-		$url_parts    = explode( '?', $pagenum_link );
-
-		if ( isset( $url_parts[1] ) ) {
-			wp_parse_str( $url_parts[1], $query_args );
-		}
-
-		$pagenum_link = remove_query_arg( array_keys( $query_args ), $pagenum_link );
-		$pagenum_link = trailingslashit( $pagenum_link ) . '%_%';
-
-		$format  = $wp_rewrite->using_index_permalinks() && ! strpos( $pagenum_link, 'index.php' ) ? 'index.php/' : '';
-		$format .= $wp_rewrite->using_permalinks() ? user_trailingslashit( $wp_rewrite->pagination_base . '/%#%', 'paged' ) : '?paged=%#%';
-
-		// Set up paginated links.
-		$links = paginate_links( array(
-			'base'     => $pagenum_link,
-			'format'   => $format,
-			'total'    => $wp_query->max_num_pages,
-			'current'  => $paged,
-			'mid_size' => 1,
-			'add_args' => array_map( 'urlencode', $query_args ),
-			'prev_text' => __( '&larr; Previous', '_s' ),
-			'next_text' => __( 'Next &rarr;', '_s' ),
-		) );
-
-		if ( $links ) :
-
-		?>
-		<nav class="navigation paging-navigation" role="navigation">
-			<h1 class="screen-reader-text"><?php esc_html_e( 'Posts navigation', '_s' ); ?></h1>
-			<div class="pagination loop-pagination">
-
-				<?php
-				echo wp_kses(
-					$links,
-					array(
-						'a' => array(
-							'href' => array(),
-							'class' => array(),
-						),
-						'span' => array(),
-					)
-				);
-				?>
-
-			</div><!-- .pagination -->
-		</nav><!-- .navigation -->
-		<?php
-
-		endif;
+	function _s_paging_nav( $args = array() ) {
+		$args = array(
+			'end_size' => 2,
+			'mid_size' => 2,
+			'prev_text' => __( '&#171 Previous page', '_s' ),
+			'next_text' => __( 'Next page &#187', '_s' ),
+			'before_page_number' => '<span class="screen-reader-text">' . __( 'Page', '_s' ) . ' </span>',
+		);
+		the_posts_pagination( $args );
 	}
 endif;
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -7,58 +7,61 @@
  * @package _s
  */
 
- if ( ! function_exists( '_s_paging_nav' ) ) :
- /**
-  * Display navigation to next/previous set of posts when applicable.
-  */
- function _s_paging_nav() {
-	 global $wp_query, $wp_rewrite;
+if ( ! function_exists( '_s_paging_nav' ) ) :
+	/**
+	 * Echo archive pagination in page numbers format.
+	 *
+	 * This is shown at the end of archives to get to another page of entries.
+	 */
+	function _s_paging_nav() {
+		global $wp_query, $wp_rewrite;
 
-// Don't print empty markup if there's only one page.
-if ( $wp_query->max_num_pages < 2 ) {
-	return;
-}
+		// Don't print empty markup if there's only one page.
+		if ( $wp_query->max_num_pages < 2 ) {
+			return;
+		}
 
-	$paged        = get_query_var( 'paged' ) ? intval( get_query_var( 'paged' ) ) : 1;
-	$pagenum_link = html_entity_decode( get_pagenum_link() );
-	$query_args   = array();
-	$url_parts    = explode( '?', $pagenum_link );
+		$paged        = get_query_var( 'paged' ) ? intval( get_query_var( 'paged' ) ) : 1;
+		$pagenum_link = html_entity_decode( get_pagenum_link() );
+		$query_args   = array();
+		$url_parts    = explode( '?', $pagenum_link );
 
-	if ( isset( $url_parts[1] ) ) {
-		wp_parse_str( $url_parts[1], $query_args );
+		if ( isset( $url_parts[1] ) ) {
+			wp_parse_str( $url_parts[1], $query_args );
+		}
+
+		$pagenum_link = remove_query_arg( array_keys( $query_args ), $pagenum_link );
+		$pagenum_link = trailingslashit( $pagenum_link ) . '%_%';
+
+		$format  = $wp_rewrite->using_index_permalinks() && ! strpos( $pagenum_link, 'index.php' ) ? 'index.php/' : '';
+		$format .= $wp_rewrite->using_permalinks() ? user_trailingslashit( $wp_rewrite->pagination_base . '/%#%', 'paged' ) : '?paged=%#%';
+
+		// Set up paginated links.
+		$links = paginate_links( array(
+			'base'     => $pagenum_link,
+			'format'   => $format,
+			'total'    => $wp_query->max_num_pages,
+			'current'  => $paged,
+			'mid_size' => 1,
+			'add_args' => array_map( 'urlencode', $query_args ),
+			'prev_text' => __( '&larr; Previous', '_s' ),
+			'next_text' => __( 'Next &rarr;', '_s' ),
+		) );
+
+		if ( $links ) :
+
+		?>
+		<nav class="navigation paging-navigation" role="navigation">
+			<h1 class="screen-reader-text"><?php esc_html_e( 'Posts navigation', '_s' ); ?></h1>
+			<div class="pagination loop-pagination">
+				<?php echo esc_html( $links ); ?>
+			</div><!-- .pagination -->
+		</nav><!-- .navigation -->
+		<?php
+
+		endif;
 	}
-
-	$pagenum_link = remove_query_arg( array_keys( $query_args ), $pagenum_link );
-	$pagenum_link = trailingslashit( $pagenum_link ) . '%_%';
-
-	$format  = $wp_rewrite->using_index_permalinks() && ! strpos( $pagenum_link, 'index.php' ) ? 'index.php/' : '';
-	$format .= $wp_rewrite->using_permalinks() ? user_trailingslashit( $wp_rewrite->pagination_base . '/%#%', 'paged' ) : '?paged=%#%';
-
-	// Set up paginated links.
-	$links = paginate_links( array(
-		'base'     => $pagenum_link,
-		'format'   => $format,
-		'total'    => $wp_query->max_num_pages,
-		'current'  => $paged,
-		'mid_size' => 1,
-		'add_args' => array_map( 'urlencode', $query_args ),
-		'prev_text' => __( '&larr; Previous', '_s' ),
-		'next_text' => __( 'Next &rarr;', '_s' ),
-	) );
-
-	if ( $links ) :
-
-	?>
-	<nav class="navigation paging-navigation" role="navigation">
-		<h1 class="screen-reader-text"><?php esc_html_e( 'Posts navigation', '_s' ); ?></h1>
-		<div class="pagination loop-pagination">
-			<?php echo $links; ?>
-		</div><!-- .pagination -->
-	</nav><!-- .navigation -->
-	<?php
-	endif;
- }
- endif;
+endif;
 
 if ( ! function_exists( '_s_posted_on' ) ) :
 /**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -18,10 +18,10 @@ if ( ! function_exists( '_s_paging_nav' ) ) :
 	 */
 	function _s_paging_nav( $args = array() ) {
 		$args = wp_parse_args( $args, array(
-			'end_size' => 2,
-			'mid_size' => 2,
-			'prev_text' => __( '← Previous page', '_s' ),
-			'next_text' => __( 'Next page →', '_s' ),
+			'end_size'  => 2,
+			'mid_size'  => 2,
+			'prev_text' => __( '&larr; Previous page', '_s' ),
+			'next_text' => __( 'Next page &rarr;', '_s' ),
 			'before_page_number' => '<span class="screen-reader-text">' . __( 'Page', '_s' ) . ' </span>',
 		) );
 		the_posts_pagination( $args );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -7,6 +7,59 @@
  * @package _s
  */
 
+ if ( ! function_exists( '_s_paging_nav' ) ) :
+ /**
+  * Display navigation to next/previous set of posts when applicable.
+  */
+ function _s_paging_nav() {
+	 global $wp_query, $wp_rewrite;
+
+// Don't print empty markup if there's only one page.
+if ( $wp_query->max_num_pages < 2 ) {
+	return;
+}
+
+	$paged        = get_query_var( 'paged' ) ? intval( get_query_var( 'paged' ) ) : 1;
+	$pagenum_link = html_entity_decode( get_pagenum_link() );
+	$query_args   = array();
+	$url_parts    = explode( '?', $pagenum_link );
+
+	if ( isset( $url_parts[1] ) ) {
+		wp_parse_str( $url_parts[1], $query_args );
+	}
+
+	$pagenum_link = remove_query_arg( array_keys( $query_args ), $pagenum_link );
+	$pagenum_link = trailingslashit( $pagenum_link ) . '%_%';
+
+	$format  = $wp_rewrite->using_index_permalinks() && ! strpos( $pagenum_link, 'index.php' ) ? 'index.php/' : '';
+	$format .= $wp_rewrite->using_permalinks() ? user_trailingslashit( $wp_rewrite->pagination_base . '/%#%', 'paged' ) : '?paged=%#%';
+
+	// Set up paginated links.
+	$links = paginate_links( array(
+		'base'     => $pagenum_link,
+		'format'   => $format,
+		'total'    => $wp_query->max_num_pages,
+		'current'  => $paged,
+		'mid_size' => 1,
+		'add_args' => array_map( 'urlencode', $query_args ),
+		'prev_text' => __( '&larr; Previous', '_s' ),
+		'next_text' => __( 'Next &rarr;', '_s' ),
+	) );
+
+	if ( $links ) :
+
+	?>
+	<nav class="navigation paging-navigation" role="navigation">
+		<h1 class="screen-reader-text"><?php esc_html_e( 'Posts navigation', '_s' ); ?></h1>
+		<div class="pagination loop-pagination">
+			<?php echo $links; ?>
+		</div><!-- .pagination -->
+	</nav><!-- .navigation -->
+	<?php
+	endif;
+ }
+ endif;
+
 if ( ! function_exists( '_s_posted_on' ) ) :
 /**
  * Prints HTML with meta information for the current post-date/time and author.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -18,10 +18,10 @@ if ( ! function_exists( '_s_paging_nav' ) ) :
 	 */
 	function _s_paging_nav( $args = array() ) {
 		$args = wp_parse_args( $args, array(
-			'end_size'  => 2,
-			'mid_size'  => 2,
-			'prev_text' => __( '&larr; Previous page', '_s' ),
-			'next_text' => __( 'Next page &rarr;', '_s' ),
+			'end_size'           => 2,
+			'mid_size'           => 2,
+			'prev_text'          => __( '&larr; Previous page', '_s' ),
+			'next_text'          => __( 'Next page &rarr;', '_s' ),
 			'before_page_number' => '<span class="screen-reader-text">' . __( 'Page', '_s' ) . ' </span>',
 		) );
 		the_posts_pagination( $args );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -17,13 +17,13 @@ if ( ! function_exists( '_s_paging_nav' ) ) :
 	 * @link https://developer.wordpress.org/reference/functions/the_posts_pagination/#parameters
 	 */
 	function _s_paging_nav( $args = array() ) {
-		$args = array(
+		$args = wp_parse_args( $args, array(
 			'end_size' => 2,
 			'mid_size' => 2,
 			'prev_text' => __( '&#171 Previous page', '_s' ),
 			'next_text' => __( 'Next page &#187', '_s' ),
 			'before_page_number' => '<span class="screen-reader-text">' . __( 'Page', '_s' ) . ' </span>',
-		);
+		) );
 		the_posts_pagination( $args );
 	}
 endif;

--- a/index.php
+++ b/index.php
@@ -40,7 +40,7 @@ get_header(); ?>
 
 			endwhile;
 
-			// Previous/next post navigation.
+			// Echo archive pagination in page numbers format.
 			_s_paging_nav();
 
 		else :

--- a/index.php
+++ b/index.php
@@ -40,7 +40,7 @@ get_header(); ?>
 
 			endwhile;
 
-			// Echo archive pagination in page numbers format.
+			// Previous/next post navigation.
 			_s_paging_nav();
 
 		else :

--- a/index.php
+++ b/index.php
@@ -40,7 +40,8 @@ get_header(); ?>
 
 			endwhile;
 
-			the_posts_navigation();
+			// Previous/next post navigation.
+			_s_paging_nav();
 
 		else :
 

--- a/index.php
+++ b/index.php
@@ -40,7 +40,6 @@ get_header(); ?>
 
 			endwhile;
 
-			// Previous/next post navigation.
 			_s_paging_nav();
 
 		else :

--- a/search.php
+++ b/search.php
@@ -35,7 +35,6 @@ get_header(); ?>
 
 			endwhile;
 
-			// Previous/next post navigation.
 			_s_paging_nav();
 
 		else :

--- a/search.php
+++ b/search.php
@@ -35,7 +35,7 @@ get_header(); ?>
 
 			endwhile;
 
-			// Echo archive pagination in page numbers format.
+			// Previous/next post navigation.
 			_s_paging_nav();
 
 		else :

--- a/search.php
+++ b/search.php
@@ -35,7 +35,7 @@ get_header(); ?>
 
 			endwhile;
 
-			// Previous/next post navigation.
+			// Echo archive pagination in page numbers format.
 			_s_paging_nav();
 
 		else :

--- a/search.php
+++ b/search.php
@@ -35,7 +35,8 @@ get_header(); ?>
 
 			endwhile;
 
-			the_posts_navigation();
+			// Previous/next post navigation.
+			_s_paging_nav();
 
 		else :
 


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Remove the `the_posts_navigation()` in `archive.php`, `index.php` and `search.php` and replaced it with a function that uses `paginate_links()`.

Reference: https://developer.wordpress.org/reference/functions/paginate_links/

#### Related issue(s): https://github.com/Automattic/_s/pull/1161