### PR TITLE
Remove the CSS rules for quotes - Issue #1192

### DIFF
--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -12,15 +12,6 @@ body {
 	background: $color__background-body; /* Fallback for when there is no custom background color defined. */
 }
 
-blockquote, q {
-	quotes: "" "";
-
-	&:before,
-	&:after {
-		content: "";
-	}
-}
-
 hr {
 	background-color: $color__background-hr;
 	border: 0;

--- a/style.css
+++ b/style.css
@@ -355,18 +355,6 @@ body {
 	background: #fff; /* Fallback for when there is no custom background color defined. */
 }
 
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-	content: "";
-}
-
-blockquote,
-q {
-	quotes: "" "";
-}
-
 hr {
 	background-color: #ccc;
 	border: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

These rules remove the default quotes set up by browsers. Most theme authors don't add anything to style the q tag. Removed these rules so that the browser defaults are used. At least the defaults handle nested quotes nicely. With these rules, no quotes at all!

#### Related issue(s):
https://github.com/Automattic/_s/issues/1192