### PR TITLE
Adding a check to make sure that the ABSPATH constant is set. If it i…

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,6 +12,9 @@
  * @package _s
  */
 
+if ( ! defined( 'ABSPATH' ) )
+	exit();
+
 get_header(); ?>
 
 	<div id="primary" class="content-area">

--- a/index.php
+++ b/index.php
@@ -12,8 +12,10 @@
  * @package _s
  */
 
-if ( ! defined( 'ABSPATH' ) )
+if ( ! defined( 'ABSPATH' ) ) {
+
 	exit();
+}
 
 get_header(); ?>
 


### PR DESCRIPTION
…sn't, then it means that someone is trying to access the theme's index.php file directly (which is undesirable).

<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

I have seen lately various attempts on sites I manage to access the theme's index.php file directly, resulting in PHP fatal errors that WordPress functions (notably, get_header()) don't exist.

By adding a check for the ABSPATH constant before get_header() on the index page, I'm avoiding these errors by quitting execution of the page. This is a precautionary measure to avoid other issues that might be exploited further on in the page's execution.

#### Related issue(s):