### PR TITLE
Fixed hard-coded URL issue given by Theme Check plugin

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,4 +1,4 @@
-<?php
+'<?php
 /**
  * The template for displaying the footer
  *
@@ -22,7 +22,7 @@
 			<span class="sep"> | </span>
 			<?php
 				/* translators: 1: Theme name, 2: Theme author. */
-				printf( esc_html__( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="' . esc_url( __( "https://automattic.com/", "_s" ) ) . '">Automattic</a>' );
+				printf( esc_html__( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="' . esc_url( __( 'https://automattic.com/', '_s' ) ) . '">Automattic</a>' );
 			?>
 		</div><!-- .site-info -->
 	</footer><!-- #colophon -->

--- a/footer.php
+++ b/footer.php
@@ -22,7 +22,7 @@
 			<span class="sep"> | </span>
 			<?php
 				/* translators: 1: Theme name, 2: Theme author. */
-				printf( esc_html__( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="https://automattic.com/">Automattic</a>' );
+				printf( esc_html__( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="' . esc_url( __( "https://automattic.com/", "_s" ) ) . '">Automattic</a>' );
 			?>
 		</div><!-- .site-info -->
 	</footer><!-- #colophon -->

--- a/footer.php
+++ b/footer.php
@@ -1,4 +1,4 @@
-'<?php
+<?php
 /**
  * The template for displaying the footer
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 
The _footer.php_ file had hard-coded URL which would generate the following issue in [Theme Check](https://wordpress.org/plugins/theme-check/) plugin:

_INFO: Possible hard-coded links were found..._

Updated that hard-coded URL so users won't need to fix it by themselves every time they use this.

#### Related issue(s):
Didn't find any related issue. Instead of creating an issue, I'm sending PR with the fix.