### PR TITLE
Travis: build against highest available PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ matrix:
           env: SNIFF=1
         # aliased to a recent 7.0.x version
         - php: '7.0'
-        # aliased to a recent 7.1.x version
-        - php: '7.1'
+        # aliased to a recent 7.2.x version
+        - php: '7.2'
         # aliased to a recent hhvm version
         - php: 'hhvm'
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The new Trusty images as per Sept 7 include an image for PHP 7.2 (even though it hasn't been released yet).

The `_s` build tests are run against the lowest/highest supported PHP version for 5 and 7.
As `7.2` is now available, it should replace the `7.1` build.
