### PR TITLE
Prevent direct access to theme files

### DIFF
--- a/404.php
+++ b/404.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 get_header(); ?>
 
 	<div id="primary" class="content-area">

--- a/archive.php
+++ b/archive.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 get_header(); ?>
 
 	<div id="primary" class="content-area">

--- a/comments.php
+++ b/comments.php
@@ -10,6 +10,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /*
  * If the current post is protected by a password and
  * the visitor has not yet entered the password we will

--- a/footer.php
+++ b/footer.php
@@ -9,6 +9,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 
 	</div><!-- #content -->

--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( ! function_exists( '_s_setup' ) ) :
 	/**
 	 * Sets up theme defaults and registers support for various WordPress features.

--- a/header.php
+++ b/header.php
@@ -9,6 +9,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 <!doctype html>
 <html <?php language_attributes(); ?>>

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -11,6 +11,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Set up the WordPress core custom header feature.
  *

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -5,6 +5,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Add postMessage support for site title and description for the Theme Customizer.
  *

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Jetpack setup function.
  *

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -5,6 +5,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Adds custom classes to the array of body classes.
  *

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( ! function_exists( '_s_posted_on' ) ) :
 	/**
 	 * Prints HTML with meta information for the current post-date/time and author.

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * WooCommerce setup function.
  *

--- a/inc/wpcom.php
+++ b/inc/wpcom.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Adds support for wp.com-specific theme functions.
  *

--- a/index.php
+++ b/index.php
@@ -12,6 +12,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 get_header(); ?>
 
 	<div id="primary" class="content-area">

--- a/page.php
+++ b/page.php
@@ -12,6 +12,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 get_header(); ?>
 
 	<div id="primary" class="content-area">

--- a/search.php
+++ b/search.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 get_header(); ?>
 
 	<section id="primary" class="content-area">

--- a/sidebar.php
+++ b/sidebar.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 	return;
 }

--- a/single.php
+++ b/single.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 get_header(); ?>
 
 	<div id="primary" class="content-area">

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 
 <section class="no-results not-found">

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>


### PR DESCRIPTION
Recently, I've noticed that my log file contains a lot of PHP errors that display this message **"PHP Fatal error: Uncaught Error: Call to undefined function get_header()..."**. I've checked the file that was mentioned in the error message and the *get_header()* function was there. I was a little bit confused because the *get_header()* function is a part of the core and I have never modified WordPress core files.

I run few tests and I've found the reason why I get these messages. It looks like somebody was trying to directly access theme files. For example, if I open this URL on my local machine (I am using VVV): 

> http://src.wordpress-develop.dev/wp-content/themes/_s/index.php 

then I get this error message:

> Fatal error: Uncaught Error: Call to undefined function get_header() in /srv/www/wordpress-develop/public_html/src/wp-content/themes/_s/index.php:15 Stack trace: #0 {main} thrown in /srv/www/wordpress-develop/public_html/src/wp-content/themes/_s/index.php on line 15

When I access files that are located in the **template-parts** folder through the URL, I do not see any error message on the screen but I see it in the log file. For example, by using this URL:

> http://src.wordpress-develop.dev/wp-content/themes/_s/template-parts/content.php

I get this error message:

> [13-Oct-2017 04:12:59 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function the_ID() in /srv/www/wordpress-develop/public_html/src/wp-content/themes/_s/template-parts/content.php:12
Stack trace:
#0 {main}
thrown in /srv/www/wordpress-develop/public_html/src/wp-content/themes/_s/template-parts/content.php on line 12

By preventing direct access to theme files, I was able to resolve the issue.