### PR TITLE
Fixing "Upload Theme" button text

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -18,7 +18,7 @@ Hi. I'm a starter theme called _s, or underscores, if you like. I'm a theme mean
 == Installation ==
 
 1. In your admin panel, go to Appearance > Themes and click the Add New button.
-2. Click Upload and Choose File, then select the theme's .zip file. Click Install Now.
+2. Click Upload Theme and Choose File, then select the theme's .zip file. Click Install Now.
 3. Click Activate to use your new theme right away.
 
 == Frequently Asked Questions ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixing theme upload button text from "Upload" to "Upload Theme" to match WordPress dashboard.