### PR TITLE
Make comments number comparison work as expected

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -28,7 +28,7 @@ if ( post_password_required() ) {
 		<h2 class="comments-title">
 			<?php
 			$comment_count = get_comments_number();
-			if ( 1 === $comment_count ) {
+			if ( '1' === $comment_count ) {
 				printf(
 					/* translators: 1: title. */
 					esc_html_e( 'One thought on &ldquo;%1$s&rdquo;', '_s' ),


### PR DESCRIPTION
`get_comments_number()` returns a numeric string, not an integer, so the strict check for comments number in `comments.php` doesn't work as expected and always returns false.

See https://core.trac.wordpress.org/changeset/41729 for the same issue in Twenty Sixteen.