### PR TITLE
Clarify "singularly identifiable articles"

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -22,7 +22,7 @@ function _s_body_classes( $classes ) {
 add_filter( 'body_class', '_s_body_classes' );
 
 /**
- * Add a pingback url auto-discovery header for singularly identifiable articles.
+ * Add a pingback url auto-discovery header for single posts, pages, or attachments.
  */
 function _s_pingback_header() {
 	if ( is_singular() && pings_open() ) {


### PR DESCRIPTION
`_s_pingback_header()` description refers to "singularly identifiable articles".

"Article" is not a native WordPress term, so I think it would be helpful to clarify what this means: single posts, pages, or attachments.