### PR TITLE
Fixing localization function inside `printf()`

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -31,7 +31,7 @@ if ( post_password_required() ) {
 			if ( 1 === $comment_count ) {
 				printf(
 					/* translators: 1: title. */
-					esc_html_e( 'One thought on &ldquo;%1$s&rdquo;', '_s' ),
+					esc_html__( 'One thought on &ldquo;%1$s&rdquo;', '_s' ),
 					'<span>' . get_the_title() . '</span>'
 				);
 			} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Making sure we don't use echoing localization functions within `printf()` and `sprintf()`.

#### Related issue(s):

Fixing #1230