### PR TITLE
Showing search input field default close button.

### DIFF
--- a/sass/_normalize.scss
+++ b/sass/_normalize.scss
@@ -175,11 +175,6 @@ input[type="number"]::-webkit-outer-spin-button {
 	height: auto;
 }
 
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-	-webkit-appearance: none;
-}
-
 fieldset {
 	border: 1px solid #c0c0c0;
 	margin: 0 2px;

--- a/style.css
+++ b/style.css
@@ -221,11 +221,6 @@ input[type="number"]::-webkit-outer-spin-button {
 	height: auto;
 }
 
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-	-webkit-appearance: none;
-}
-
 fieldset {
 	border: 1px solid #c0c0c0;
 	margin: 0 2px;


### PR DESCRIPTION
The search input field default close button was hidden though CSS property `-webkit-appearance: none;`.
![Search Close Button](http://bsf.io/u94pt)

<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s): 