### PR TITLE
Remove aria-hidden='true' from a tabbable item in the featured image

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -122,7 +122,7 @@ function _s_post_thumbnail() {
 
 	<?php else : ?>
 
-	<a class="post-thumbnail" href="<?php the_permalink(); ?>" aria-hidden="true">
+	<a class="post-thumbnail" href="<?php the_permalink(); ?>">
 		<?php
 			the_post_thumbnail( 'post-thumbnail', array(
 				'alt' => the_title_attribute( array(


### PR DESCRIPTION
This PR removes the `aria-hidden="true"` from the link in the featured image markup to improve accessibility.

See #1158 for more information.