### PR TITLE
Add 'tabindex=-1' to the featured image markup, to improve accessibil…

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -132,7 +132,7 @@ function _s_post_thumbnail() {
 
 	<?php else : ?>
 
-	<a class="post-thumbnail" href="<?php the_permalink(); ?>" aria-hidden="true">
+	<a class="post-thumbnail" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
 		<?php
 			the_post_thumbnail( 'post-thumbnail', array(
 				'alt' => the_title_attribute( array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is a reworking of #1243 based on feedback there. Rather than removing the `aria-hidden="true"` from Featured Images, it adds `tabindex="-1"

This update is to address missed feedback in #1158.