### PR TITLE
Fix an issue with input[type='search'] styling

### DIFF
--- a/sass/_normalize.scss
+++ b/sass/_normalize.scss
@@ -175,9 +175,13 @@ input[type="number"]::-webkit-outer-spin-button {
 	height: auto;
 }
 
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-	-webkit-appearance: none;
+input[type="search"] {
+	-webkit-appearance: textfield;
+
+	&::-webkit-search-cancel-button,
+	&::-webkit-search-decoration {
+		-webkit-appearance: none;
+	}
 }
 
 fieldset {


### PR DESCRIPTION


<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
For `input[type='search']`, I added `-webkit-appearance: textfield;`. Otherwise, styles won't be applied. Read more here: [https://github.com/h5bp/html5-boilerplate/issues/396](https://github.com/h5bp/html5-boilerplate/issues/396)

#### Related issue(s):
