### PR TITLE
Update minimum version requirement

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: automattic
 Tags: custom-background, custom-logo, custom-menu, featured-images, threaded-comments, translation-ready
 
-Requires at least: 4.0
+Requires at least: 4.5
 Tested up to: 4.8
 Stable tag: 1.0.0
 License: GNU General Public License v2 or later


### PR DESCRIPTION
the_custom_logo() was introduced in WP 4.5, so the requirement needed to be updated to reflect this. Fixes #1249

#### Changes proposed in this Pull Request:


#### Related issue(s):