### PR TITLE
Two travis tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,11 @@ matrix:
         - php: '7.0'
         # aliased to a recent 7.2.x version
         - php: '7.2'
-        # aliased to a recent hhvm version
-        - php: 'hhvm'
+        # bleeding edge PHP
+        - php: 'nightly'
 
     allow_failures:
-        - php: 'hhvm'
+        - php: 'nightly'
 
 # Use this to prepare the system to install prerequisites or dependencies.
 # e.g. sudo apt-get update.

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ matrix:
 # e.g. copy database configurations, environment variables, etc.
 # Failures in this section will result in build status 'errored'.
 before_script:
+    # Speed up build time by disabling Xdebug.
+    - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+    # Set up temporary paths.
     - export PHPCS_DIR=/tmp/phpcs
     - export SNIFFS_DIR=/tmp/sniffs
     # Install CodeSniffer for WordPress Coding Standards checks.


### PR DESCRIPTION
### Travis: speed up build times by disabling Xdebug

Xdebug is only **needed** when creating code coverage reports. Otherwise, it's just a nice extra, but a slow extra.
Disabling it will speed up the build times.

As suggested by John Blackbourn in https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/

With an additional improvement to stabilize the command as suggested by Niklas Keller in  https://twitter.com/kelunik/status/954242454676475904

----
### Travis: stop build testing against HHVM, test against nightly

At some point in time, PHP was lagging behind and HHVM seemed like the future. What with PHP 7 being released and doing incredibly well, that time has passed and the popularity of HHVM is now marginal.

This commit drops testing against HHVM and starts testing against bleeding edge PHP nightly instead.

