### PR TITLE
Fix datetime values

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -18,9 +18,9 @@ if ( ! function_exists( '_s_posted_on' ) ) :
 		}
 
 		$time_string = sprintf( $time_string,
-			esc_attr( get_the_date( 'c' ) ),
+			esc_attr( get_the_date( DATE_W3C ) ),
 			esc_html( get_the_date() ),
-			esc_attr( get_the_modified_date( 'c' ) ),
+			esc_attr( get_the_modified_date( DATE_W3C ) ),
 			esc_html( get_the_modified_date() )
 		);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Use the date format `DATE_W3C` instead of `'c'` when populating `datetime` attributes. See trac [#20973](https://core.trac.wordpress.org/ticket/20973).

`get_the_date( 'c' )` will return the post date, which appears to be in local time (per the timezone setting), except that it appends `+00:00`. Therefore, it's technically the wrong time. Using `DATE_W3C` as the date format renders in the same format but appends the correct offset.