### PR TITLE
Use composer to install PHPCS and friends on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,19 +48,13 @@ matrix:
 before_script:
     # Speed up build time by disabling Xdebug.
     - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-    # Set up temporary paths.
-    - export PHPCS_DIR=/tmp/phpcs
-    - export WPCS_DIR=/tmp/wpcs
-    - export PHPCOMPAT_DIR=/tmp/phpcompatibility
-    # Install CodeSniffer for WordPress Coding Standards checks.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
-    # Install WordPress Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b 0.14.1 --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
-    # Install PHP Compatibility sniffs.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
+    # Install WordPress Coding Standards & PHP Compatibility sniffs.
+    - if [[ "$SNIFF" == "1" ]]; then composer global require wp-coding-standards/wpcs:~0.14.1 wimg/php-compatibility:dev-master --prefer-stable --no-interaction --no-suggest; fi
+    # Set composer PATH.
+    - if [[ "$SNIFF" == "1" ]]; then export PATH=$HOME/.composer/vendor/bin:$PATH; fi
     # Set install path for PHPCS sniffs.
     # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs,$HOME/.composer/vendor/wimg/php-compatibility; fi
     # After CodeSniffer install you should refresh your path.
     - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
     # Install JSCS: JavaScript Code Style checker.
@@ -87,7 +81,7 @@ script:
     # @link https://pear.php.net/package/PHP_CodeSniffer/
     # Uses a custom ruleset based on WordPress. This ruleset is automatically
     # picked up by PHPCS as it's named `phpcs.xml(.dist)`.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
+    - if [[ "$SNIFF" == "1" ]]; then phpcs --runtime-set ignore_warnings_on_exit 1; fi
 
 # Receive notifications for build results.
 # @link https://docs.travis-ci.com/user/notifications/#Email-notifications

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,9 @@ before_script:
     # Speed up build time by disabling Xdebug.
     - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
     # Install WordPress Coding Standards & PHP Compatibility sniffs.
-    - if [[ "$SNIFF" == "1" ]]; then composer global require wp-coding-standards/wpcs:~0.14.1 wimg/php-compatibility:dev-master --prefer-stable --no-interaction --no-suggest; fi
+    - if [[ "$SNIFF" == "1" ]]; then composer global require wp-coding-standards/wpcs:~0.14.1 wimg/php-compatibility:dev-master dealerdirect/phpcodesniffer-composer-installer:^0.4.3 --prefer-stable --no-interaction --no-suggest; fi
     # Set composer PATH.
     - if [[ "$SNIFF" == "1" ]]; then export PATH=$HOME/.composer/vendor/bin:$PATH; fi
-    # Set install path for PHPCS sniffs.
-    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - if [[ "$SNIFF" == "1" ]]; then phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs,$HOME/.composer/vendor/wimg/php-compatibility; fi
     # After CodeSniffer install you should refresh your path.
     - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
     # Install JSCS: JavaScript Code Style checker.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Use composer instead of git to install WPCS and PHPCompatibility. This was recommend in a previous PR https://github.com/Automattic/_s/pull/1183#issuecomment-315844661

Changing the flow to https://github.com/Automattic/_s/pull/1267/commits/a0d2892cadbc290ac7e4eb507c7e5cfc55202a53

Only use the development version of PHPCompatibility. With this change we would use the stable version of PHPCS.  Due to an update to the PHPCS master the checks are failing. I would like to the necessary changes to happen along side the PHPCS and WPCS updates instead of having to do them with other changes.

#### Related issue(s):
#1267