### PR TITLE
Add basic composer.json file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "_s",
+    "description": "Hi. I'm a starter theme called '_s', or 'underscores', if you like. I'm a theme meant for hacking so don't use me as a parent theme. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.",
+    "type": "wordpress-theme",
+    "license": "GPL-2.0 or later",
+    "version": "1.0.0"
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
I'd be helpful to be able to require the _s theme via Composer using the [Composer Installers](https://github.com/composer/installers) package, which would automatically place the `wordpress-theme` type in the specified themes directory. 

An example of how someone might leverage this Composer file can be seen here: 
https://github.com/alexmacarthur/wp-skateboard/tree/starter-theme-underscores

As a solution to all of this, I've created a very basic `composer.json` file. It can certainly be improved, but contains all the essential information as a starting point. 