### PR TITLE
Bottom margin in image alignment & fix for travis ci build errors

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -56,9 +56,9 @@ if ( ! function_exists( '_s_header_style' ) ) :
 			.site-description {
 				position: absolute;
 				clip: rect(1px, 1px, 1px, 1px);
-			}
-		<?php
-		// If the user has set a custom color for the text use that.
+				}
+			<?php
+			// If the user has set a custom color for the text use that.
 		else :
 			?>
 			.site-title a,

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -175,7 +175,7 @@ if ( ! function_exists( '_s_woocommerce_wrapper_after' ) ) {
 	 * @return void
 	 */
 	function _s_woocommerce_wrapper_after() {
-			?>
+		?>
 			</main><!-- #main -->
 		</div><!-- #primary -->
 		<?php

--- a/sass/modules/_alignments.scss
+++ b/sass/modules/_alignments.scss
@@ -2,15 +2,18 @@
 	display: inline;
 	float: left;
 	margin-right: 1.5em;
+	margin-bottom: 1.5em;
 }
 
 .alignright {
 	display: inline;
 	float: right;
 	margin-left: 1.5em;
+	margin-bottom: 1.5em;
 }
 
 .aligncenter {
 	clear: both;
 	@include center-block;
+	margin-bottom: 1.5em;
 }

--- a/style.css
+++ b/style.css
@@ -776,12 +776,14 @@ a:hover, a:active {
 	display: inline;
 	float: left;
 	margin-right: 1.5em;
+	margin-bottom: 1.5em;
 }
 
 .alignright {
 	display: inline;
 	float: right;
 	margin-left: 1.5em;
+	margin-bottom: 1.5em;
 }
 
 .aligncenter {
@@ -789,6 +791,7 @@ a:hover, a:active {
 	display: block;
 	margin-left: auto;
 	margin-right: auto;
+	margin-bottom: 1.5em;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
As proposed in #1273, `margin-botom: 1.5em;` added to all three image alignment classes (`.alignleft`, `.alignright` and `.aligncenter`). Files edited - `_alignments.scss` and `style.css`

I was also getting some kind of unrelated error in Travis CI builds since the last PR. So I checked the build log([1164](https://travis-ci.org/Automattic/_s/builds/397226363)). There were a few lines that had some wrong style formatting in `inc/woocommerce.php` and `inc/custom-header.php`. After fixing those, all builds is passing without any errors.