### PR TITLE
Remove unnecessary aria-expanded attribute on ul

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -25,7 +25,6 @@
 		return;
 	}
 
-	menu.setAttribute( 'aria-expanded', 'false' );
 	if ( -1 === menu.className.indexOf( 'nav-menu' ) ) {
 		menu.className += ' nav-menu';
 	}
@@ -34,11 +33,9 @@
 		if ( -1 !== container.className.indexOf( 'toggled' ) ) {
 			container.className = container.className.replace( ' toggled', '' );
 			button.setAttribute( 'aria-expanded', 'false' );
-			menu.setAttribute( 'aria-expanded', 'false' );
 		} else {
 			container.className += ' toggled';
 			button.setAttribute( 'aria-expanded', 'true' );
-			menu.setAttribute( 'aria-expanded', 'true' );
 		}
 	};
 
@@ -49,7 +46,6 @@
 		if ( ! isClickInside ) {
 			container.className = container.className.replace( ' toggled', '' );
 			button.setAttribute( 'aria-expanded', 'false' );
-			menu.setAttribute( 'aria-expanded', 'false' );
 		}
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Remove `aria-expanded` attribute from `<ul>` element, as it should only be applied to the button controlling the showing/hiding of the menu. (See [my comment](https://github.com/Automattic/_s/issues/1289#issuecomment-400845419) on #1289 for more detail.)

#### Related issue(s):
Fixes https://github.com/Automattic/_s/issues/1289