### PR TITLE
Move wp_link_pages() within footer element

### DIFF
--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -17,36 +17,32 @@
 	<?php _s_post_thumbnail(); ?>
 
 	<div class="entry-content">
-		<?php
-		the_content();
+		<?php the_content(); ?>
+	</div><!-- .entry-content -->
 
+	<footer class="entry-footer">
+		<?php
 		wp_link_pages( array(
 			'before' => '<div class="page-links">' . esc_html__( 'Pages:', '_s' ),
 			'after'  => '</div>',
 		) );
-		?>
-	</div><!-- .entry-content -->
 
-	<?php if ( get_edit_post_link() ) : ?>
-		<footer class="entry-footer">
-			<?php
-			edit_post_link(
-				sprintf(
-					wp_kses(
-						/* translators: %s: Name of current post. Only visible to screen readers */
-						__( 'Edit <span class="screen-reader-text">%s</span>', '_s' ),
-						array(
-							'span' => array(
-								'class' => array(),
-							),
-						)
-					),
-					get_the_title()
+		edit_post_link(
+			sprintf(
+				wp_kses(
+					/* translators: %s: Name of current post. Only visible to screen readers */
+					__( 'Edit <span class="screen-reader-text">%s</span>', '_s' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
 				),
-				'<span class="edit-link">',
-				'</span>'
-			);
-			?>
-		</footer><!-- .entry-footer -->
-	<?php endif; ?>
+				get_the_title()
+			),
+			'<span class="edit-link">',
+			'</span>'
+		);
+		?>
+	</footer><!-- .entry-footer -->
 </article><!-- #post-<?php the_ID(); ?> -->

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -45,15 +45,17 @@
 			),
 			get_the_title()
 		) );
-
-		wp_link_pages( array(
-			'before' => '<div class="page-links">' . esc_html__( 'Pages:', '_s' ),
-			'after'  => '</div>',
-		) );
 		?>
 	</div><!-- .entry-content -->
 
 	<footer class="entry-footer">
-		<?php _s_entry_footer(); ?>
+		<?php
+		wp_link_pages( array(
+			'before' => '<div class="page-links">' . esc_html__( 'Pages:', '_s' ),
+			'after'  => '</div>',
+		) );
+
+		_s_entry_footer();
+		?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-<?php the_ID(); ?> -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Move `wp_link_pages()` within footer element.

#### Related issue(s):
fixes #1294