### PR TITLE
CS/QA update for WPCS 1.0.0, PHPCS 3.3.1 & PHPCompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ matrix:
           dist: precise
         # aliased to a recent 5.6.x version
         - php: '5.6'
-          env: SNIFF=1
         # aliased to a recent 7.0.x version
         - php: '7.0'
         # aliased to a recent 7.2.x version
         - php: '7.2'
+          env: SNIFF=1
         # bleeding edge PHP
         - php: 'nightly'
 
@@ -56,7 +56,7 @@ before_script:
     # Install CodeSniffer for WordPress Coding Standards checks.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
     # Install WordPress Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b 0.14.1 --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b 1.0.0 --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
     # Install PHP Compatibility sniffs.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/PHPCompatibility/PHPCompatibility.git $PHPCOMPAT_DIR; fi
     # Install WP PHP Compatibility ruleset.

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,15 +52,18 @@ before_script:
     - export PHPCS_DIR=/tmp/phpcs
     - export WPCS_DIR=/tmp/wpcs
     - export PHPCOMPAT_DIR=/tmp/phpcompatibility
+    - export PHPCOMPATWP_DIR=/tmp/phpcompatibilitywp
     # Install CodeSniffer for WordPress Coding Standards checks.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
     # Install WordPress Coding Standards.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b 0.14.1 --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
     # Install PHP Compatibility sniffs.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/PHPCompatibility/PHPCompatibility.git $PHPCOMPAT_DIR; fi
+    # Install WP PHP Compatibility ruleset.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/PHPCompatibility/PHPCompatibilityWP.git $PHPCOMPATWP_DIR; fi
     # Set install path for PHPCS sniffs.
     # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR,$PHPCOMPATWP_DIR; fi
     # After CodeSniffer install you should refresh your path.
     - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
     # Install JSCS: JavaScript Code Style checker.

--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,11 @@
  * @package _s
  */
 
+if ( ! defined( '_S_VERSION' ) ) {
+	// Replace #.# with the version number of the theme on each release.
+	define( '_S_VERSION', '#.#' );
+}
+
 if ( ! function_exists( '_s_setup' ) ) :
 	/**
 	 * Sets up theme defaults and registers support for various WordPress features.
@@ -120,11 +125,11 @@ add_action( 'widgets_init', '_s_widgets_init' );
  * Enqueue scripts and styles.
  */
 function _s_scripts() {
-	wp_enqueue_style( '_s-style', get_stylesheet_uri() );
+	wp_enqueue_style( '_s-style', get_stylesheet_uri(), array(), _S_VERSION );
 
-	wp_enqueue_script( '_s-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20151215', true );
+	wp_enqueue_script( '_s-navigation', get_template_directory_uri() . '/js/navigation.js', array(), _S_VERSION, true );
 
-	wp_enqueue_script( '_s-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
+	wp_enqueue_script( '_s-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), _S_VERSION, true );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -4,7 +4,7 @@
  *
  * You can add an optional custom header image to header.php like so ...
  *
-	<?php the_header_image_tag(); ?>
+ * <?php the_header_image_tag(); ?>
  *
  * @link https://developer.wordpress.org/themes/functionality/custom-headers/
  *
@@ -57,9 +57,9 @@ if ( ! function_exists( '_s_header_style' ) ) :
 				position: absolute;
 				clip: rect(1px, 1px, 1px, 1px);
 			}
-		<?php
-		// If the user has set a custom color for the text use that.
+			<?php
 		else :
+			// If the user has set a custom color for the text use that.
 			?>
 			.site-title a,
 			.site-description {

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -29,7 +29,7 @@ add_action( 'after_setup_theme', '_s_woocommerce_setup' );
  * @return void
  */
 function _s_woocommerce_scripts() {
-	wp_enqueue_style( '_s-woocommerce-style', get_template_directory_uri() . '/woocommerce.css' );
+	wp_enqueue_style( '_s-woocommerce-style', get_template_directory_uri() . '/woocommerce.css', array(), _S_VERSION );
 
 	$font_path   = WC()->plugin_url() . '/assets/fonts/';
 	$inline_font = '@font-face {

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -103,8 +103,8 @@ add_filter( 'loop_shop_columns', '_s_woocommerce_loop_columns' );
 /**
  * Related Products Args.
  *
- * @param array $args related products args.
- * @return array $args related products args.
+ * @param array $args Related products args.
+ * @return array $args Related products args.
  */
 function _s_woocommerce_related_products_args( $args ) {
 	$defaults = array(
@@ -175,7 +175,7 @@ if ( ! function_exists( '_s_woocommerce_wrapper_after' ) ) {
 	 * @return void
 	 */
 	function _s_woocommerce_wrapper_after() {
-			?>
+		?>
 			</main><!-- #main -->
 		</div><!-- #primary -->
 		<?php
@@ -188,11 +188,11 @@ add_action( 'woocommerce_after_main_content', '_s_woocommerce_wrapper_after' );
  *
  * You can add the WooCommerce Mini Cart to header.php like so ...
  *
-	<?php
-		if ( function_exists( '_s_woocommerce_header_cart' ) ) {
-			_s_woocommerce_header_cart();
-		}
-	?>
+ * <?php
+ *     if ( function_exists( '_s_woocommerce_header_cart' ) ) {
+ *         _s_woocommerce_header_cart();
+ *     }
+ * ?>
  */
 
 if ( ! function_exists( '_s_woocommerce_cart_link_fragment' ) ) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -97,36 +97,7 @@
 	#############################################################################
 	-->
 
-
-	<config name="testVersion" value="5.2-99.0"/>
-	<rule ref="PHPCompatibility">
-		<!-- Whitelist PHP native classes, interfaces, functions and constants which
-			 are back-filled by WP.
-
-			 Based on:
-			 * /wp-includes/compat.php
-			 * /wp-includes/random_compat/random.php
-		-->
-		<exclude name="PHPCompatibility.PHP.NewClasses.errorFound"/>
-		<exclude name="PHPCompatibility.PHP.NewClasses.typeerrorFound"/>
-
-		<exclude name="PHPCompatibility.PHP.NewConstants.json_pretty_printFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.php_version_idFound"/>
-
-		<exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound"/>
-		<exclude name="PHPCompatibility.PHP.NewFunctions.json_last_error_msgFound"/>
-		<exclude name="PHPCompatibility.PHP.NewFunctions.random_intFound"/>
-		<exclude name="PHPCompatibility.PHP.NewFunctions.random_bytesFound"/>
-		<exclude name="PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound"/>
-
-		<exclude name="PHPCompatibility.PHP.NewInterfaces.jsonserializableFound"/>
-	</rule>
-
-	<!-- Whitelist the WP Core mysql_to_rfc3339() function. -->
-	<rule ref="PHPCompatibility.PHP.RemovedExtensions">
-		<properties>
-			<property name="functionWhitelist" type="array" value="mysql_to_rfc3339"/>
-		</properties>
-	</rule>
+	<config name="testVersion" value="5.2-"/>
+	<rule ref="PHPCompatibilityWP"/>
 
 </ruleset>


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

## Changes proposed in this Pull Request:

This PR updates the CS/QA related toolset to use the latest versions of these tools and updates the code-base to comply.

## Commit details:

### QA: Break stylesheets out of browser cache on each new release of a theme

_WPCS 1.0.0 contains a new sniff which identifies this issue, which is why it has to be solved for the update to be possible_

**Type: Functional change**

The `wp_enqueue_style()` function allows for passing a `$version` parameter which is used to force browsers to load a fresh copy of a stylesheet when it has been changed.

If this parameter is not passed, the version number will be set to the version of the WP install which doesn't make sense at all for a theme which is not shipped with WP itself.

This commit adds a `_S_VERSION` constant which should be changed to the current version number of the actual finished theme on each new release.

This constant is subsequently used in all `wp_enqueue_style()` function calls to ensure that on each new release of the theme, the browser cache is cleared for these stylesheets.

Ref: https://developer.wordpress.org/reference/functions/wp_enqueue_style/

---

### CS: Minor fixes to comply with WPCS 1.0.0 / PHPCS 3.3.1

**Type: CS update**

Nothing very interesting, just some minor fixes to comply with the latest versions of all sniffs being tested against.

---

### Use PHPCompatibilityWP

**Type: Build tools**

Since mid July, the PHPCompatibility project offers dedicated CMS rulesets which already account for all back-fills/poly-fills.

This commit removes the `_s` native version of that ruleset in favour of using this dedicated WP-based ruleset.

Additionally, the PHPCompatibility repo has moved to a dedicated GitHub organisation, so that change is included here as well.

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/8.2.0
* https://github.com/phpcompatibility/phpcompatibilitywp

**Note**: I would strongly recommend installing these dependencies via Composer instead. @grappler has created a good setup for this in PR #1291 which I would recommend for merging, though it will need to be updated to be in line with the changes made in this PR.

---

### Use WPCS 1.0.0 and sniff against a high PHP version for the fastest and most reliable results.

**Type: Build tools**

No ruleset changes are needed.

Refs: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.0.0

