### PR TITLE
Print skip-link-focus-fix inline instead of enqueueing as blocking script

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -124,13 +124,26 @@ function _s_scripts() {
 
 	wp_enqueue_script( '_s-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20151215', true );
 
-	wp_enqueue_script( '_s-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
-
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );
 	}
 }
 add_action( 'wp_enqueue_scripts', '_s_scripts' );
+
+/**
+ * Fix skip link focus in IE11.
+ *
+ * This does not enqueue the script because it is tiny and because it is only for IE11,
+ * thus it does not warrant having an entire dedicated blocking script being loaded.
+ *
+ * @link https://git.io/vWdr2
+ */
+function _s_skip_link_focus_fix() {
+	echo '<script>';
+	echo file_get_contents( get_template_directory() . '/js/skip-link-focus-fix.js' );
+	echo '</script>';
+}
+add_action( 'wp_print_footer_scripts', '_s_skip_link_focus_fix' );
 
 /**
  * Implement the Custom Header feature.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Enqueueing scripts is very costly since the browser will block rendering until the script is loaded. What's more is that it is only applicable in IE11, so it is particularly bad to have this blocking script loaded for 90% of browsers which will never use it. (If IE11 supported conditional comments, those could have been used here, but it does not.) Blocking scripts should be minimized as much as possible, either by adding the `async` attribute or by outputting the `script` inline.

While core doesn't yet have built-in support for `async`, core does currently add an inline script for adding the emoji logic (`print_emoji_detection_script()`/`_print_emoji_detection_script()`). A similar approach is proposed here for the `skip-link-focus-fix` script. Just like for the emoji detection script, the skip-link-focus-fix is small in size and it is only applicable to IE11.

#### Related issue(s):

#1206 