### PR TITLE
chore(phpcs): Fix compatibility with PHPCompatibility 9.0

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -123,7 +123,7 @@
 	</rule>
 
 	<!-- Whitelist the WP Core mysql_to_rfc3339() function. -->
-	<rule ref="PHPCompatibility.PHP.RemovedExtensions">
+	<rule ref="PHPCompatibility.Extensions.RemovedExtensions">
 		<properties>
 			<property name="functionWhitelist" type="array" value="mysql_to_rfc3339"/>
 		</properties>


### PR DESCRIPTION
Since the PHPCompatibility version 9, the sniff PHP.RemovedExtensions has been renamed to Extensions.RemovedExtensions.
This commit renames it to the new name so that the PHPCS works now correctly.

https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0