### PR TITLE
[ UPDATE ] Opening parenthesis of a multi-line function call must be …

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -50,10 +50,12 @@ if ( post_password_required() ) {
 
 		<ol class="comment-list">
 			<?php
-			wp_list_comments( array(
-				'style'      => 'ol',
-				'short_ping' => true,
-			) );
+			wp_list_comments(
+				array(
+					'style'      => 'ol',
+					'short_ping' => true,
+				)
+			);
 			?>
 		</ol><!-- .comment-list -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
wp_list_comments update to remove WPCS error -> Opening parenthesis of a multi-line function call must be the last content on the line.

#### Related issue(s):