### PR TITLE
Improved font rendering on OS X

### DIFF
--- a/sass/_normalize.scss
+++ b/sass/_normalize.scss
@@ -17,11 +17,14 @@ html {
 	 ========================================================================== */
 
 /**
- * Remove the margin in all browsers.
+ * 1. Remove the margin in all browsers.
+ * 2. Improving font rendering on OS X
  */
 
 body {
-	margin: 0;
+	margin: 0; /* 1 */
+	-webkit-font-smoothing: antialiased; /* 2 */
+	-moz-osx-font-smoothing: grayscale; /* 2 */
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -63,11 +63,14 @@ html {
 	 ========================================================================== */
 
 /**
- * Remove the margin in all browsers.
+ * 1. Remove the margin in all browsers.
+ * 2. Improving font rendering on OS X
  */
 
 body {
-	margin: 0;
+	margin: 0; /* 1 */
+	-webkit-font-smoothing: antialiased; /* 2 */
+	-moz-osx-font-smoothing: grayscale; /* 2 */
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Some fonts (e.g. [Google's Roboto](https://github.com/google/roboto)) look much thicker on OS X because of different font rendering. This can be fixed by following code:
`-webkit-font-smoothing: antialiased;
-moz-osx-font-smoothing: grayscale;`

As far as I know there are no performance issues related to this.

More about alleged readability decrease is mentioned following Material Components [issue discussion](https://github.com/material-components/material-components-web/issues/248). (TL;DR: removing `-webkit-font-smoothing:antialiased` was marked as `wontfix`).