### PR TITLE
Modify post thumbnail output to display the alt text if set.

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -134,10 +134,14 @@ if ( ! function_exists( '_s_post_thumbnail' ) ) :
 
 		<a class="post-thumbnail" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
 			<?php
-			the_post_thumbnail( 'post-thumbnail', array(
-				'alt' => the_title_attribute( array(
+			$post_thumbnail_alt = get_post_meta( get_post_thumbnail_id(), '_wp_attachment_image_alt', true );
+			if( empty( $post_thumbnail_alt ) ) {
+				$post_thumbnail_alt = the_title_attribute( array(
 					'echo' => false,
-				) ),
+				) );
+			}
+			the_post_thumbnail( 'post-thumbnail', array(
+				'alt' => sanitize_text_field( $post_thumbnail_alt ),
 			) );
 			?>
 		</a>


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
When the post thumbnail is output on an index view, the alt text will output what is set in the Media Library for the thumbnail. If it's not set, the alt text will output the post title.

#### Related issue(s):
#1328 