### PR TITLE
Add wp_body_open() and shim for sites older than 5.2

### DIFF
--- a/header.php
+++ b/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', '_s' ); ?></a>
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -146,3 +146,14 @@ if ( ! function_exists( '_s_post_thumbnail' ) ) :
 		endif; // End is_singular().
 	}
 endif;
+
+if ( ! function_exists( 'wp_body_open' ) ) :
+	/**
+	 * Shim for sites older than 5.2.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/12563
+	 */
+	function wp_body_open() {
+		do_action( 'wp_body_open' );
+	}
+endif;


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

wp_body_open() is introduced in 5.2 to allow the adding of <script> code. This pull request adds the functionality to _s and introduces a shim for older WordPress versions.