### PR TITLE
SASS Warning: Display: inline no effect with Float

### DIFF
--- a/sass/modules/_alignments.scss
+++ b/sass/modules/_alignments.scss
@@ -1,11 +1,9 @@
 .alignleft {
-	display: inline;
 	float: left;
 	margin-right: 1.5em;
 }
 
 .alignright {
-	display: inline;
 	float: right;
 	margin-left: 1.5em;
 }


### PR DESCRIPTION

<img width="811" alt="Screenshot 2019-05-27 at 16 47 46" src="https://user-images.githubusercontent.com/12336032/58430159-2bd4cd80-80a0-11e9-94fe-a19d2be66f15.png">

SASS Warning shows up. 
"Property is ignored due to the display. With 'display: inline', the width, height, margin-top, margin-bottom, and float properties have no effect."

This can be found when using the VSCode editor.

#### Changes proposed in this Pull Request:
Remove `display: inline` from classese `.alignleft`, `.alignright`.

#### Related issue(s):
N/A