### PR TITLE
Image alignment: Make them full-width in mobile devices

### DIFF
--- a/sass/modules/_alignments.scss
+++ b/sass/modules/_alignments.scss
@@ -1,13 +1,26 @@
-.alignleft {
-	display: inline;
-	float: left;
-	margin-right: 1.5em;
+.alignleft,
+.alignright{
+	width: 100%;
+	margin-bottom: 0.5em;
 }
 
-.alignright {
-	display: inline;
-	float: right;
-	margin-left: 1.5em;
+@media (min-width: 37.5em) {
+	.alignleft,
+	.alignright{
+		width: auto;
+	}
+
+	.alignleft {
+		display: inline;
+		float: left;
+		margin-right: 1.5em;
+	}
+
+	.alignright {
+		display: inline;
+		float: right;
+		margin-left: 1.5em;
+	}
 }
 
 .aligncenter {


### PR DESCRIPTION
Make `.alignleft` and `.alignright` full-width on mobile devices

Closes #1376

#### Changes proposed in this Pull Request:
Make `.alignleft` and `.alignright` full-width on mobile devices