### PR TITLE
Close small menu when user clicks outside #1375

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -42,6 +42,17 @@
 		}
 	};
 
+    // Close small menu when user clicks outside
+    document.addEventListener( 'click', function( event ) {
+        var isClickInside = container.contains( event.target );
+
+        if ( ! isClickInside ) {
+            container.className = container.className.replace( ' toggled', '' );
+            button.setAttribute( 'aria-expanded', 'false' );
+            menu.setAttribute( 'aria-expanded', 'false' );
+        }
+    } );
+
 	// Get all the link elements within the menu.
 	links = menu.getElementsByTagName( 'a' );
 

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -42,16 +42,16 @@
 		}
 	};
 
-    // Close small menu when user clicks outside
-    document.addEventListener( 'click', function( event ) {
-        var isClickInside = container.contains( event.target );
+	// Close small menu when user clicks outside
+	document.addEventListener( 'click', function( event ) {
+		var isClickInside = container.contains( event.target );
 
-        if ( ! isClickInside ) {
-            container.className = container.className.replace( ' toggled', '' );
-            button.setAttribute( 'aria-expanded', 'false' );
-            menu.setAttribute( 'aria-expanded', 'false' );
-        }
-    } );
+		if ( ! isClickInside ) {
+			container.className = container.className.replace( ' toggled', '' );
+			button.setAttribute( 'aria-expanded', 'false' );
+			menu.setAttribute( 'aria-expanded', 'false' );
+		}
+	} );
 
 	// Get all the link elements within the menu.
 	links = menu.getElementsByTagName( 'a' );


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
When small (mobile) menu is toggled open, this feature closes the menu when the user taps or clicks outside the #site-navigation container variable.

#### Related issue(s):
Fixes #1375 