### PR TITLE
Add SASS compilation and sync the CSS files

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,6 +8,8 @@
     "rules": {
         "font-family-no-missing-generic-family-keyword": null,
         "no-descending-specificity": null,
-        "block-no-empty": null
+        "block-no-empty": null,
+        "no-duplicate-selectors": null,
+        "font-family-no-duplicate-names": null
     }
 }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
       "url": "https://github.com/Automattic/_s/issues"
     },
     "devDependencies": {
-      "@wordpress/scripts": "^7.2.0"
+        "node-sass": "^4.13.1",
+        "@wordpress/scripts": "^7.2.0"
     },
     "scripts": {
-      "lint:scss": "wp-scripts lint-style 'sass/**/*.scss'",
-      "lint:js": "wp-scripts lint-js 'js/*.js'"
+        "compile:css": "node-sass sass/style.scss style.css && node-sass sass/woocommerce.scss woocommerce.css && stylelint '*.css' --fix || true && stylelint '*.css' --fix",
+        "lint:scss": "wp-scripts lint-style 'sass/**/*.scss'",
+        "lint:js": "wp-scripts lint-js 'js/*.js'"
     }
 }

--- a/rtl.css
+++ b/rtl.css
@@ -1,8 +1,8 @@
 /*
 Theme Name: _s
 
-Adding support for languages written in a Right To Left (RTL) direction is easy -
-it's just a matter of overwriting all the horizontal positioning attributes
+Adding support for languages written in a Right To Left (RTL) direction is easy.
+It's just a matter of overwriting all the horizontal positioning attributes
 of your CSS stylesheet in a separate stylesheet file named rtl.css.
 
 https://codex.wordpress.org/Right-to-Left_Language_Support

--- a/sass/_normalize.scss
+++ b/sass/_normalize.scss
@@ -9,8 +9,8 @@
  */
 
 html {
-	line-height: 1.15; /* 1 */
-	-webkit-text-size-adjust: 100%; /* 2 */
+	line-height: 1.15;
+	-webkit-text-size-adjust: 100%;
 }
 
 /* Sections
@@ -43,9 +43,9 @@ h1 {
  */
 
 hr {
-	box-sizing: content-box; /* 1 */
-	height: 0; /* 1 */
-	overflow: visible; /* 2 */
+	box-sizing: content-box;
+	height: 0;
+	overflow: visible;
 }
 
 /**
@@ -54,8 +54,8 @@ hr {
  */
 
 pre {
-	font-family: monospace, monospace; /* 1 */
-	font-size: 1em; /* 2 */
+	font-family: monospace, monospace;
+	font-size: 1em;
 }
 
 /* Text-level semantics
@@ -75,9 +75,9 @@ a {
  */
 
 abbr[title] {
-	border-bottom: none; /* 1 */
-	text-decoration: underline; /* 2 */
-	text-decoration: underline dotted; /* 2 */
+	border-bottom: none;
+	text-decoration: underline;
+	text-decoration: underline dotted;
 }
 
 /**
@@ -97,8 +97,8 @@ strong {
 code,
 kbd,
 samp {
-	font-family: monospace, monospace; /* 1 */
-	font-size: 1em; /* 2 */
+	font-family: monospace, monospace;
+	font-size: 1em;
 }
 
 /**
@@ -154,10 +154,10 @@ input,
 optgroup,
 select,
 textarea {
-	font-family: inherit; /* 1 */
-	font-size: 100%; /* 1 */
-	line-height: 1.15; /* 1 */
-	margin: 0; /* 2 */
+	font-family: inherit;
+	font-size: 100%;
+	line-height: 1.15;
+	margin: 0;
 }
 
 /**
@@ -166,7 +166,7 @@ textarea {
  */
 
 button,
-input { /* 1 */
+input {
 	overflow: visible;
 }
 
@@ -176,7 +176,7 @@ input { /* 1 */
  */
 
 button,
-select { /* 1 */
+select {
 	text-transform: none;
 }
 
@@ -230,12 +230,12 @@ fieldset {
  */
 
 legend {
-	box-sizing: border-box; /* 1 */
-	color: inherit; /* 2 */
-	display: table; /* 1 */
-	max-width: 100%; /* 1 */
-	padding: 0; /* 3 */
-	white-space: normal; /* 1 */
+	box-sizing: border-box;
+	color: inherit;
+	display: table;
+	max-width: 100%;
+	padding: 0;
+	white-space: normal;
 }
 
 /**
@@ -261,8 +261,8 @@ textarea {
 
 [type="checkbox"],
 [type="radio"] {
-	box-sizing: border-box; /* 1 */
-	padding: 0; /* 2 */
+	box-sizing: border-box;
+	padding: 0;
 }
 
 /**
@@ -280,8 +280,8 @@ textarea {
  */
 
 [type="search"] {
-	-webkit-appearance: textfield; /* 1 */
-	outline-offset: -2px; /* 2 */
+	-webkit-appearance: textfield;
+	outline-offset: -2px;
 }
 
 /**
@@ -298,8 +298,8 @@ textarea {
  */
 
 ::-webkit-file-upload-button {
-	-webkit-appearance: button; /* 1 */
-	font: inherit; /* 2 */
+	-webkit-appearance: button;
+	font: inherit;
 }
 
 /* Interactive

--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -11,7 +11,7 @@ html {
 }
 
 body {
-	background: $color__background-body; /* Fallback for when there is no custom background color defined. */
+	background: $color__background-body; // Fallback for when there is no custom background color defined.
 }
 
 hr {
@@ -24,12 +24,12 @@ hr {
 @import "lists";
 
 img {
-	height: auto; /* Make sure images are scaled correctly. */
-	max-width: 100%; /* Adhere to container width. */
+	height: auto; // Make sure images are scaled correctly.
+	max-width: 100%; // Adhere to container width.
 }
 
 figure {
-	margin: 1em 0; /* Extra wide images within figure tags don't overflow the content area. */
+	margin: 1em 0; // Extra wide images within figure tags don't overflow the content area.
 }
 
 @import "tables";

--- a/sass/modules/_accessibility.scss
+++ b/sass/modules/_accessibility.scss
@@ -9,7 +9,7 @@
 	padding: 0;
 	position: absolute !important;
 	width: 1px;
-	word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+	word-wrap: normal !important; // Many screen reader and browser combinations announce broken words as they would appear visually.
 
 	&:focus {
 		background-color: $color__background-screen;
@@ -30,7 +30,7 @@
 		text-decoration: none;
 		top: 5px;
 		width: auto;
-		z-index: 100000; /* Above WP toolbar. */
+		z-index: 100000; // Above WP toolbar.
 	}
 }
 

--- a/sass/modules/_infinite-scroll.scss
+++ b/sass/modules/_infinite-scroll.scss
@@ -1,6 +1,5 @@
-/* Hide the Older / Newer Posts Navigation when Infinite Scroll is in use. */
+/* Hide the Posts Navigation and the Footer when Infinite Scroll is in use. */
 .infinite-scroll .posts-navigation,
-/* Hide the Theme Footer (when set to scrolling) */
 .infinite-scroll.neverending .site-footer {
 	display: none;
 }

--- a/sass/shop/_checkout.scss
+++ b/sass/shop/_checkout.scss
@@ -1,6 +1,3 @@
-/**
- * Checkout
- */
 @media screen and (min-width: 768px) {
 
 	.col2-set {

--- a/sass/shop/_products.scss
+++ b/sass/shop/_products.scss
@@ -1,6 +1,3 @@
-/**
- * Products
- */
 ul.products {
 
 	@include clearfix;

--- a/sass/shop/_single-product.scss
+++ b/sass/shop/_single-product.scss
@@ -1,6 +1,3 @@
-/**
- * Single Product
- */
 .single-product {
 
 	div.product {

--- a/sass/shop/_tables.scss
+++ b/sass/shop/_tables.scss
@@ -1,6 +1,3 @@
-/**
- * Shop tables
- */
 table.shop_table_responsive {
 
 	thead {

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -1,7 +1,7 @@
 .widget {
 	margin: 0 0 1.5em;
 
-	/* Make sure select elements fit in widgets. */
+	// Make sure select elements fit in widgets.
 	select {
 		max-width: 100%;
 	}

--- a/sass/woocommerce.scss
+++ b/sass/woocommerce.scss
@@ -4,16 +4,12 @@ Theme Name: _s
 WooCommerce styles override
 */
 
-/**
- * WooCommerce color variables
- */
+// WooCommerce color variables
 $woocommerce__color-error: #e2401c;
 $woocommerce__color-success: #0f834d;
 $woocommerce__color-info: #3d9cd2;
 
-/**
- * Imports
- */
+// Imports
 @import "variables-site/variables-site";
 @import "mixins/mixins-master";
 

--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@ Text Domain: _s
 Tags: custom-background, custom-logo, custom-menu, featured-images, threaded-comments, translation-ready
 
 This theme, like WordPress, is licensed under the GPL.
-Use it to make something cool, have fun, and share what you've learned with others.
+Use it to make something cool, have fun, and share what you've learned.
 
 _s is based on Underscores https://underscores.me/, (C) 2012-2020 Automattic, Inc.
 Underscores is distributed under the terms of the GNU GPL v2 or later.
@@ -19,6 +19,7 @@ Underscores is distributed under the terms of the GNU GPL v2 or later.
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 */
+
 /*--------------------------------------------------------------
 >>> TABLE OF CONTENTS:
 ----------------------------------------------------------------
@@ -41,10 +42,12 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	## Captions
 	## Galleries
 --------------------------------------------------------------*/
+
 /*--------------------------------------------------------------
 # Normalize
 --------------------------------------------------------------*/
-/* normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
+
+/*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
 
 /* Document
 	 ========================================================================== */
@@ -53,10 +56,9 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
  * 1. Correct the line height in all browsers.
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
-
 html {
-	line-height: 1.15; /* 1 */
-	-webkit-text-size-adjust: 100%; /* 2 */
+	line-height: 1.15;
+	-webkit-text-size-adjust: 100%;
 }
 
 /* Sections
@@ -65,7 +67,6 @@ html {
 /**
  * Remove the margin in all browsers.
  */
-
 body {
 	margin: 0;
 }
@@ -74,7 +75,6 @@ body {
  * Correct the font size and margin on `h1` elements within `section` and
  * `article` contexts in Chrome, Firefox, and Safari.
  */
-
 h1 {
 	font-size: 2em;
 	margin: 0.67em 0;
@@ -87,21 +87,19 @@ h1 {
  * 1. Add the correct box sizing in Firefox.
  * 2. Show the overflow in Edge and IE.
  */
-
 hr {
-	box-sizing: content-box; /* 1 */
-	height: 0; /* 1 */
-	overflow: visible; /* 2 */
+	box-sizing: content-box;
+	height: 0;
+	overflow: visible;
 }
 
 /**
  * 1. Correct the inheritance and scaling of font size in all browsers.
  * 2. Correct the odd `em` font sizing in all browsers.
  */
-
 pre {
-	font-family: monospace, monospace; /* 1 */
-	font-size: 1em; /* 2 */
+	font-family: monospace, monospace;
+	font-size: 1em;
 }
 
 /* Text-level semantics
@@ -110,7 +108,6 @@ pre {
 /**
  * Remove the gray background on active links in IE 10.
  */
-
 a {
 	background-color: transparent;
 }
@@ -119,17 +116,15 @@ a {
  * 1. Remove the bottom border in Chrome 57-
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
-
 abbr[title] {
-	border-bottom: none; /* 1 */
-	text-decoration: underline; /* 2 */
-	text-decoration: underline dotted; /* 2 */
+	border-bottom: none;
+	text-decoration: underline;
+	text-decoration: underline dotted;
 }
 
 /**
  * Add the correct font weight in Chrome, Edge, and Safari.
  */
-
 b,
 strong {
 	font-weight: bolder;
@@ -139,18 +134,16 @@ strong {
  * 1. Correct the inheritance and scaling of font size in all browsers.
  * 2. Correct the odd `em` font sizing in all browsers.
  */
-
 code,
 kbd,
 samp {
-	font-family: monospace, monospace; /* 1 */
-	font-size: 1em; /* 2 */
+	font-family: monospace, monospace;
+	font-size: 1em;
 }
 
 /**
  * Add the correct font size in all browsers.
  */
-
 small {
 	font-size: 80%;
 }
@@ -159,7 +152,6 @@ small {
  * Prevent `sub` and `sup` elements from affecting the line height in
  * all browsers.
  */
-
 sub,
 sup {
 	font-size: 75%;
@@ -182,7 +174,6 @@ sup {
 /**
  * Remove the border on images inside links in IE 10.
  */
-
 img {
 	border-style: none;
 }
@@ -194,25 +185,23 @@ img {
  * 1. Change the font styles in all browsers.
  * 2. Remove the margin in Firefox and Safari.
  */
-
 button,
 input,
 optgroup,
 select,
 textarea {
-	font-family: inherit; /* 1 */
-	font-size: 100%; /* 1 */
-	line-height: 1.15; /* 1 */
-	margin: 0; /* 2 */
+	font-family: inherit;
+	font-size: 100%;
+	line-height: 1.15;
+	margin: 0;
 }
 
 /**
  * Show the overflow in IE.
  * 1. Show the overflow in Edge.
  */
-
 button,
-input { /* 1 */
+input {
 	overflow: visible;
 }
 
@@ -220,16 +209,14 @@ input { /* 1 */
  * Remove the inheritance of text transform in Edge, Firefox, and IE.
  * 1. Remove the inheritance of text transform in Firefox.
  */
-
 button,
-select { /* 1 */
+select {
 	text-transform: none;
 }
 
 /**
  * Correct the inability to style clickable types in iOS and Safari.
  */
-
 button,
 [type="button"],
 [type="reset"],
@@ -240,7 +227,6 @@ button,
 /**
  * Remove the inner border and padding in Firefox.
  */
-
 button::-moz-focus-inner,
 [type="button"]::-moz-focus-inner,
 [type="reset"]::-moz-focus-inner,
@@ -252,7 +238,6 @@ button::-moz-focus-inner,
 /**
  * Restore the focus styles unset by the previous rule.
  */
-
 button:-moz-focusring,
 [type="button"]:-moz-focusring,
 [type="reset"]:-moz-focusring,
@@ -263,7 +248,6 @@ button:-moz-focusring,
 /**
  * Correct the padding in Firefox.
  */
-
 fieldset {
 	padding: 0.35em 0.75em 0.625em;
 }
@@ -274,20 +258,18 @@ fieldset {
  * 3. Remove the padding so developers are not caught out when they zero out
  *		`fieldset` elements in all browsers.
  */
-
 legend {
-	box-sizing: border-box; /* 1 */
-	color: inherit; /* 2 */
-	display: table; /* 1 */
-	max-width: 100%; /* 1 */
-	padding: 0; /* 3 */
-	white-space: normal; /* 1 */
+	box-sizing: border-box;
+	color: inherit;
+	display: table;
+	max-width: 100%;
+	padding: 0;
+	white-space: normal;
 }
 
 /**
  * Add the correct vertical alignment in Chrome, Firefox, and Opera.
  */
-
 progress {
 	vertical-align: baseline;
 }
@@ -295,7 +277,6 @@ progress {
 /**
  * Remove the default vertical scrollbar in IE 10+.
  */
-
 textarea {
 	overflow: auto;
 }
@@ -304,17 +285,15 @@ textarea {
  * 1. Add the correct box sizing in IE 10.
  * 2. Remove the padding in IE 10.
  */
-
 [type="checkbox"],
 [type="radio"] {
-	box-sizing: border-box; /* 1 */
-	padding: 0; /* 2 */
+	box-sizing: border-box;
+	padding: 0;
 }
 
 /**
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
-
 [type="number"]::-webkit-inner-spin-button,
 [type="number"]::-webkit-outer-spin-button {
 	height: auto;
@@ -324,16 +303,14 @@ textarea {
  * 1. Correct the odd appearance in Chrome and Safari.
  * 2. Correct the outline style in Safari.
  */
-
 [type="search"] {
-	-webkit-appearance: textfield; /* 1 */
-	outline-offset: -2px; /* 2 */
+	-webkit-appearance: textfield;
+	outline-offset: -2px;
 }
 
 /**
  * Remove the inner padding in Chrome and Safari on macOS.
  */
-
 [type="search"]::-webkit-search-decoration {
 	-webkit-appearance: none;
 }
@@ -342,10 +319,9 @@ textarea {
  * 1. Correct the inability to style clickable types in iOS and Safari.
  * 2. Change font properties to `inherit` in Safari.
  */
-
 ::-webkit-file-upload-button {
-	-webkit-appearance: button; /* 1 */
-	font: inherit; /* 2 */
+	-webkit-appearance: button;
+	font: inherit;
 }
 
 /* Interactive
@@ -354,7 +330,6 @@ textarea {
 /*
  * Add the correct display in Edge, IE 10+, and Firefox.
  */
-
 details {
 	display: block;
 }
@@ -362,7 +337,6 @@ details {
 /*
  * Add the correct display in all browsers.
  */
-
 summary {
 	display: list-item;
 }
@@ -373,7 +347,6 @@ summary {
 /**
  * Add the correct display in IE 10+.
  */
-
 template {
 	display: none;
 }
@@ -381,7 +354,6 @@ template {
 /**
  * Add the correct display in IE 10.
  */
-
 [hidden] {
 	display: none;
 }
@@ -402,7 +374,12 @@ textarea {
 	line-height: 1.5;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
 	clear: both;
 }
 
@@ -410,7 +387,10 @@ p {
 	margin-bottom: 1.5em;
 }
 
-dfn, cite, em, i {
+dfn,
+cite,
+em,
+i {
 	font-style: italic;
 }
 
@@ -424,7 +404,7 @@ address {
 
 pre {
 	background: #eee;
-	font-family: "Courier 10 Pitch", Courier, monospace;
+	font-family: "Courier 10 Pitch", courier, monospace;
 	font-size: 15px;
 	font-size: 0.9375rem;
 	line-height: 1.6;
@@ -434,18 +414,23 @@ pre {
 	padding: 1.6em;
 }
 
-code, kbd, tt, var {
-	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+code,
+kbd,
+tt,
+var {
+	font-family: monaco, consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 	font-size: 15px;
 	font-size: 0.9375rem;
 }
 
-abbr, acronym {
+abbr,
+acronym {
 	border-bottom: 1px dotted #666;
 	cursor: help;
 }
 
-mark, ins {
+mark,
+ins {
 	background: #fff9c0;
 	text-decoration: none;
 }
@@ -457,20 +442,21 @@ big {
 /*--------------------------------------------------------------
 # Elements
 --------------------------------------------------------------*/
+
+/* Inherit box-sizing to more easily change it's value on a component level.
+@link http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
+*,
+*::before,
+*::after {
+	box-sizing: inherit;
+}
+
 html {
 	box-sizing: border-box;
 }
 
-*,
-*:before,
-*:after {
-	/* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
-	box-sizing: inherit;
-}
-
 body {
 	background: #fff;
-	/* Fallback for when there is no custom background color defined. */
 }
 
 hr {
@@ -480,7 +466,8 @@ hr {
 	margin-bottom: 1.5em;
 }
 
-ul, ol {
+ul,
+ol {
 	margin: 0 0 1.5em 3em;
 }
 
@@ -499,7 +486,7 @@ li > ol {
 }
 
 dt {
-	font-weight: bold;
+	font-weight: 700;
 }
 
 dd {
@@ -508,14 +495,11 @@ dd {
 
 img {
 	height: auto;
-	/* Make sure images are scaled correctly. */
 	max-width: 100%;
-	/* Adhere to container width. */
 }
 
 figure {
 	margin: 1em 0;
-	/* Extra wide images within figure tags don't overflow the content area. */
 }
 
 table {
@@ -538,7 +522,7 @@ input[type="submit"] {
 	font-size: 12px;
 	font-size: 0.75rem;
 	line-height: 1;
-	padding: .6em 1em .4em;
+	padding: 0.6em 1em 0.4em;
 }
 
 button:hover,
@@ -548,7 +532,8 @@ input[type="submit"]:hover {
 	border-color: #ccc #bbb #aaa;
 }
 
-button:active, button:focus,
+button:active,
+button:focus,
 input[type="button"]:active,
 input[type="button"]:focus,
 input[type="reset"]:active,
@@ -610,26 +595,30 @@ textarea {
 /*--------------------------------------------------------------
 # Navigation
 --------------------------------------------------------------*/
+
 /*--------------------------------------------------------------
 ## Links
 --------------------------------------------------------------*/
 a {
-	color: royalblue;
+	color: #4169e1;
 }
 
 a:visited {
-	color: purple;
+	color: #800080;
 }
 
-a:hover, a:focus, a:active {
-	color: midnightblue;
+a:hover,
+a:focus,
+a:active {
+	color: #191970;
 }
 
 a:focus {
 	outline: thin dotted;
 }
 
-a:hover, a:active {
+a:hover,
+a:active {
 	outline: 0;
 }
 
@@ -695,16 +684,20 @@ a:hover, a:active {
 }
 
 @media screen and (min-width: 37.5em) {
+
 	.menu-toggle {
 		display: none;
 	}
+
 	.main-navigation ul {
 		display: block;
 	}
 }
 
-.site-main .comment-navigation, .site-main
-.posts-navigation, .site-main
+.site-main .comment-navigation,
+.site-main
+.posts-navigation,
+.site-main
 .post-navigation {
 	margin: 0 0 1.5em;
 	overflow: hidden;
@@ -728,6 +721,7 @@ a:hover, a:active {
 /*--------------------------------------------------------------
 # Accessibility
 --------------------------------------------------------------*/
+
 /* Text meant only for screen readers. */
 .screen-reader-text {
 	border: 0;
@@ -739,7 +733,7 @@ a:hover, a:active {
 	padding: 0;
 	position: absolute !important;
 	width: 1px;
-	word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+	word-wrap: normal !important;
 }
 
 .screen-reader-text:focus {
@@ -752,7 +746,7 @@ a:hover, a:active {
 	display: block;
 	font-size: 14px;
 	font-size: 0.875rem;
-	font-weight: bold;
+	font-weight: 700;
 	height: auto;
 	left: 5px;
 	line-height: normal;
@@ -761,7 +755,6 @@ a:hover, a:active {
 	top: 5px;
 	width: auto;
 	z-index: 100000;
-	/* Above WP toolbar. */
 }
 
 /* Do not show the outline on the skip link target. */
@@ -797,29 +790,29 @@ a:hover, a:active {
 /*--------------------------------------------------------------
 # Clearings
 --------------------------------------------------------------*/
-.clear:before,
-.clear:after,
-.entry-content:before,
-.entry-content:after,
-.comment-content:before,
-.comment-content:after,
-.site-header:before,
-.site-header:after,
-.site-content:before,
-.site-content:after,
-.site-footer:before,
-.site-footer:after {
+.clear::before,
+.clear::after,
+.entry-content::before,
+.entry-content::after,
+.comment-content::before,
+.comment-content::after,
+.site-header::before,
+.site-header::after,
+.site-content::before,
+.site-content::after,
+.site-footer::before,
+.site-footer::after {
 	content: "";
 	display: table;
 	table-layout: fixed;
 }
 
-.clear:after,
-.entry-content:after,
-.comment-content:after,
-.site-header:after,
-.site-content:after,
-.site-footer:after {
+.clear::after,
+.entry-content::after,
+.comment-content::after,
+.site-header::after,
+.site-content::after,
+.site-footer::after {
 	clear: both;
 }
 
@@ -828,7 +821,6 @@ a:hover, a:active {
 --------------------------------------------------------------*/
 .widget {
 	margin: 0 0 1.5em;
-	/* Make sure select elements fit in widgets. */
 }
 
 .widget select {
@@ -838,6 +830,7 @@ a:hover, a:active {
 /*--------------------------------------------------------------
 # Content
 --------------------------------------------------------------*/
+
 /*--------------------------------------------------------------
 ## Posts and pages
 --------------------------------------------------------------*/
@@ -879,14 +872,14 @@ a:hover, a:active {
 /*--------------------------------------------------------------
 # Infinite scroll
 --------------------------------------------------------------*/
-/* Globally hidden elements when Infinite Scroll is supported and in use. */
+
+/* Hide the Posts Navigation and the Footer when Infinite Scroll is in use. */
 .infinite-scroll .posts-navigation,
 .infinite-scroll.neverending .site-footer {
-	/* Theme Footer (when set to scrolling) */
 	display: none;
 }
 
-/* When Infinite Scroll has reached its end we need to re-display elements that were hidden (via .neverending) before. */
+/* Re-display the Theme Footer when Infinite Scroll has reached its end. */
 .infinity-end.neverending .site-footer {
 	display: block;
 }

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -3,15 +3,7 @@ Theme Name: _s
 
 WooCommerce styles override
 */
-/**
- * WooCommerce color variables
- */
-/**
- * Imports
- */
-/**
- * Shop tables
- */
+
 /**
  * Shop tables
  */
@@ -29,7 +21,7 @@ table.shop_table_responsive tr td {
 	clear: both;
 }
 
-table.shop_table_responsive tr td:before {
+table.shop_table_responsive tr td::before {
 	content: attr(data-title) ": ";
 	float: left;
 }
@@ -38,11 +30,12 @@ table.shop_table_responsive tr td.product-remove a {
 	text-align: left;
 }
 
-table.shop_table_responsive tr td.product-remove:before {
+table.shop_table_responsive tr td.product-remove::before {
 	display: none;
 }
 
-table.shop_table_responsive tr td.actions:before, table.shop_table_responsive tr td.download-actions:before {
+table.shop_table_responsive tr td.actions::before,
+table.shop_table_responsive tr td.download-actions::before {
 	display: none;
 }
 
@@ -52,26 +45,29 @@ table.shop_table_responsive tr td.download-actions .button {
 }
 
 @media screen and (min-width: 48em) {
+
 	table.shop_table_responsive thead {
 		display: table-header-group;
 	}
+
 	table.shop_table_responsive tbody th {
 		display: table-cell;
 	}
-	table.shop_table_responsive tr th, table.shop_table_responsive tr td {
+
+	table.shop_table_responsive tr th,
+	table.shop_table_responsive tr td {
 		text-align: left;
 	}
+
 	table.shop_table_responsive tr td {
 		display: table-cell;
 	}
-	table.shop_table_responsive tr td:before {
+
+	table.shop_table_responsive tr td::before {
 		display: none;
 	}
 }
 
-/**
- * Products
- */
 /**
  * Products
  */
@@ -102,43 +98,49 @@ ul.products li.product .button {
 }
 
 @media screen and (min-width: 48em) {
+
 	ul.products li.product {
-		width: 30.7966666667%;
+		width: 30.79667%;
 		float: left;
 		margin-right: 3.8%;
 	}
+
 	ul.products li.product.first {
 		clear: both;
 	}
+
 	ul.products li.product.last {
 		margin-right: 0;
 	}
+
 	.columns-1 ul.products li.product {
 		float: none;
 		width: 100%;
 	}
+
 	.columns-2 ul.products li.product {
 		width: 48.1%;
 	}
+
 	.columns-3 ul.products li.product {
-		width: 30.7966666667%;
+		width: 30.79667%;
 	}
+
 	.columns-4 ul.products li.product {
 		width: 22.15%;
 	}
+
 	.columns-5 ul.products li.product {
 		width: 16.96%;
 	}
+
 	.columns-6 ul.products li.product {
-		width: 13.4933333333%;
+		width: 13.49333%;
 	}
 }
 
 /**
  * Single product
- */
-/**
- * Single Product
  */
 .single-product div.product {
 	content: "";
@@ -178,7 +180,7 @@ ul.products li.product .button {
 }
 
 .single-product div.product .woocommerce-product-gallery .flex-control-thumbs li img {
-	opacity: .5;
+	opacity: 0.5;
 }
 
 .single-product div.product .woocommerce-product-gallery .flex-control-thumbs li img.flex-active {
@@ -202,7 +204,7 @@ ul.products li.product .button {
 }
 
 .single-product div.product .woocommerce-product-gallery.woocommerce-product-gallery--columns-3 .flex-control-thumbs li {
-	width: 30.7966666667%;
+	width: 30.79667%;
 }
 
 .single-product div.product .woocommerce-product-gallery.woocommerce-product-gallery--columns-3 .flex-control-thumbs li:nth-child(3n) {
@@ -237,7 +239,7 @@ ul.products li.product .button {
 	clear: both;
 }
 
-.stock:empty:before {
+.stock:empty::before {
 	display: none;
 }
 
@@ -252,18 +254,18 @@ ul.products li.product .button {
 /**
  * Checkout
  */
-/**
- * Checkout
- */
 @media screen and (min-width: 768px) {
+
 	.col2-set .form-row-first {
 		float: left;
 		margin-right: 3.8%;
 	}
+
 	.col2-set .form-row-last {
 		float: right;
 		margin-right: 0;
 	}
+
 	.col2-set .form-row-first,
 	.col2-set .form-row-last {
 		width: 48.1%;
@@ -273,6 +275,7 @@ ul.products li.product .button {
 /**
  * General WooCommerce components
  */
+
 /**
  * Header cart
  */
@@ -308,13 +311,13 @@ ul.products li.product .button {
 	line-height: 1.618;
 	font-size: 1em;
 	width: 5.3em;
-	font-family: 'star';
+	font-family: star;
 	font-weight: 400;
 }
 
-.star-rating:before {
+.star-rating::before {
 	content: "\53\53\53\53\53";
-	opacity: .25;
+	opacity: 0.25;
 	float: left;
 	top: 0;
 	left: 0;
@@ -330,12 +333,12 @@ ul.products li.product .button {
 	padding-top: 1.5em;
 }
 
-.star-rating span:before {
+.star-rating span::before {
 	content: "\53\53\53\53\53";
 	top: 0;
 	position: absolute;
 	left: 0;
-	color: royalblue;
+	color: #4169e1;
 }
 
 p.stars a {
@@ -349,7 +352,7 @@ p.stars a {
 	font-weight: 400;
 }
 
-p.stars a:before {
+p.stars a::before {
 	display: block;
 	position: absolute;
 	top: 0;
@@ -357,40 +360,40 @@ p.stars a:before {
 	width: 1em;
 	height: 1em;
 	line-height: 1;
-	font-family: "star";
+	font-family: star;
 	content: "\53";
 	color: #404040;
 	text-indent: 0;
-	opacity: .25;
+	opacity: 0.25;
 }
 
-p.stars a:hover ~ a:before {
+p.stars a:hover ~ a::before {
 	content: "\53";
 	color: #404040;
-	opacity: .25;
+	opacity: 0.25;
 }
 
-p.stars:hover a:before {
+p.stars:hover a::before {
 	content: "\53";
-	color: royalblue;
+	color: #4169e1;
 	opacity: 1;
 }
 
-p.stars.selected a.active:before {
+p.stars.selected a.active::before {
 	content: "\53";
-	color: royalblue;
+	color: #4169e1;
 	opacity: 1;
 }
 
-p.stars.selected a.active ~ a:before {
+p.stars.selected a.active ~ a::before {
 	content: "\53";
 	color: #404040;
-	opacity: .25;
+	opacity: 0.25;
 }
 
-p.stars.selected a:not(.active):before {
+p.stars.selected a:not(.active)::before {
 	content: "\53";
-	color: royalblue;
+	color: #4169e1;
 	opacity: 1;
 }
 
@@ -439,7 +442,7 @@ p.stars.selected a:not(.active):before {
 }
 
 .woocommerce-password-strength.good {
-	color: #3D9CD2;
+	color: #3d9cd2;
 }
 
 /**
@@ -454,7 +457,7 @@ p.stars.selected a:not(.active):before {
 }
 
 .required {
-	color: red;
+	color: #f00;
 }
 
 /**
@@ -475,7 +478,7 @@ p.no-comments {
 .woocommerce-info,
 .woocommerce-noreviews,
 p.no-comments {
-	background-color: #3D9CD2;
+	background-color: #3d9cd2;
 }
 
 .woocommerce-error {
@@ -489,11 +492,12 @@ p.no-comments {
 	right: 0;
 	margin: 0;
 	padding: 1em;
-	background-color: #3D9CD2;
+	background-color: #3d9cd2;
 	z-index: 9999;
 }
 
 @media screen and (min-width: 48em) {
+
 	/**
 	 * Header cart
 	 */
@@ -506,7 +510,9 @@ p.no-comments {
 		display: block;
 		box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
 	}
-	.site-header-cart:hover .widget_shopping_cart, .site-header-cart.focus .widget_shopping_cart {
+
+	.site-header-cart:hover .widget_shopping_cart,
+	.site-header-cart.focus .widget_shopping_cart {
 		left: 0;
 		display: block;
 	}
@@ -515,6 +521,7 @@ p.no-comments {
 /**
  * WooCommerce widgets
  */
+
 /**
  * WooCommerce Price Filter
  */
@@ -524,7 +531,7 @@ p.no-comments {
 
 .widget_price_filter .price_slider_amount {
 	text-align: right;
-	line-height: 2.4em;
+	line-height: 2.4;
 }
 
 .widget_price_filter .price_slider_amount .button {
@@ -543,9 +550,9 @@ p.no-comments {
 	height: 1em;
 	cursor: ew-resize;
 	outline: none;
-	background: royalblue;
+	background: #4169e1;
 	box-sizing: border-box;
-	margin-top: -.25em;
+	margin-top: -0.25em;
 	opacity: 1;
 }
 
@@ -553,7 +560,8 @@ p.no-comments {
 	margin-left: -1em;
 }
 
-.widget_price_filter .ui-slider .ui-slider-handle:hover, .widget_price_filter .ui-slider .ui-slider-handle.ui-state-active {
+.widget_price_filter .ui-slider .ui-slider-handle:hover,
+.widget_price_filter .ui-slider .ui-slider-handle.ui-state-active {
 	box-shadow: 0 0 0 0.25em rgba(0, 0, 0, 0.1);
 }
 
@@ -562,7 +570,7 @@ p.no-comments {
 	z-index: 1;
 	display: block;
 	border: 0;
-	background: royalblue;
+	background: #4169e1;
 }
 
 .widget_price_filter .price_slider_wrapper .ui-widget-content {
@@ -570,7 +578,7 @@ p.no-comments {
 }
 
 .widget_price_filter .ui-slider-horizontal {
-	height: .5em;
+	height: 0.5em;
 }
 
 .widget_price_filter .ui-slider-horizontal .ui-slider-range {


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

In this PR I added the command `compile:css` to package.json to compile SASS files using node-sass. The problem is that node-sass has some weird behavior when it comes to comments and nesting. This is something that is known since the early attempts to automate the compilation of CSS https://github.com/Automattic/_s/pull/1168#issuecomment-314131813.

To address this issue, I chained `stylelint --fix` script to node-sass in `compile:css` command, but that was not enough, because stylelint didn't fix all the issue in the first pass. So I made the `compile:css` command run the  `stylelint --fix` twice :

`"compile:css": "node-sass sass/style.scss style.css && node-sass sass/woocommerce.scss woocommerce.css && stylelint '*.css' --fix || true && stylelint '*.css' --fix"`

For the CSS inline comment problem, I borrowed the solution suggested by @m-e-h in the comment mentioned above. And by the way I removed some redundant comments.

The changes made to style.css and woocommerce.css were generated using the `compile:css` command.

#### Related issue(s):
https://github.com/Automattic/_s/issues/1149, https://github.com/Automattic/_s/pull/1159, https://github.com/Automattic/_s/pull/1168, https://github.com/Automattic/_s/pull/1237, https://github.com/Automattic/_s/pull/1221, https://github.com/Automattic/_s/pull/932