### PR TITLE
Declare HTML5 scripts and styles support for better compliance with W3C validator

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -66,6 +66,8 @@ if ( ! function_exists( '_s_setup' ) ) :
 				'comment-list',
 				'gallery',
 				'caption',
+				'style',
+				'script',
 			)
 		);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Hi,

Given this theme is written in HTML5, it should declare HTML5 support for styles and script to avoid using `type` attributes in styles and scripts.

Otherwise, W3C validator will throw a warning because of the `type` element.

This option was introduced in WordPress 5.3. For reference, see:
- https://make.wordpress.org/core/2019/10/15/miscellaneous-developer-focused-changes-in-5-3/
- https://core.trac.wordpress.org/ticket/42804#comment:32

#### Related issue(s):
Fixes #1400 