### PR TITLE
Remove an unnecessary ARIA role

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -119,7 +119,7 @@ if ( ! function_exists( '_s_woocommerce_wrapper_before' ) ) {
 	function _s_woocommerce_wrapper_before() {
 		?>
 		<div id="primary" class="content-area">
-			<main id="main" class="site-main" role="main">
+			<main id="main" class="site-main">
 			<?php
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
In https://github.com/Automattic/_s/issues/1132 the ARIA roles were removed, but one instance got reintroduced in this PR https://github.com/Automattic/_s/pull/1191. This PR removes it, so the main wrapper of WooCommerce pages and the other ones match.