### PR TITLE
Bump the Linux distribution on Travis from Trusty to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@
 # For use with the Underscores WordPress theme.
 # @link https://github.com/Automattic/_s
 
-# Tell Travis CI which distro to use.
-dist: trusty
+# Tell Travis CI which OS and which distro to use.
+os: linux
+dist: xenial
 
 # Cache directories between builds.
 # @link https://docs.travis-ci.com/user/caching/#arbitrary-directories
@@ -30,7 +31,7 @@ php:
   - 7.2
   - 7.3
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - php: 7.4


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR switch the default Linux distribution on Travis CI from Ubuntu Trusty to Ubuntu Xenial. It also define explicitly the OS, and changes matrix to jobs.