### PR TITLE
Use stylelint and eslint directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,12 @@
     "url": "https://github.com/Automattic/_s/issues"
   },
   "devDependencies": {
-    "@wordpress/scripts": "^7.2.0",
+    "@wordpress/eslint-plugin": "^4.1.0",
+    "eslint": "^6.8.0",
     "node-sass": "^4.13.1",
-    "rtlcss": "^2.5.0"
+    "rtlcss": "^2.5.0",
+    "stylelint": "^13.3.2",
+    "stylelint-config-wordpress": "^16.0.0"
   },
   "rtlcssConfig": {
     "options": {
@@ -37,7 +40,7 @@
   "scripts": {
     "compile:css": "node-sass sass/style.scss style.css && node-sass sass/woocommerce.scss woocommerce.css && stylelint '*.css' --fix || true && stylelint '*.css' --fix",
     "compile:rtl": "rtlcss style.css style-rtl.css",
-    "lint:scss": "wp-scripts lint-style 'sass/**/*.scss'",
-    "lint:js": "wp-scripts lint-js 'js/*.js'"
+    "lint:scss": "stylelint 'sass/**/*.scss'",
+    "lint:js": "eslint 'js/*.js'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node-sass": "^4.13.1",
     "rtlcss": "^2.5.0",
     "stylelint": "^13.3.2",
-    "stylelint-config-wordpress": "^16.0.0"
+    "stylelint-config-wordpress": "^15.0.0"
   },
   "rtlcssConfig": {
     "options": {


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

@wordpress/scripts is a huge package with some huge dependencies, but it's only being used for linting, which are just tiny wrapper scripts around stylelint and eslint.  

I propose to use stylelint and eslint directly.  This reduced npm install time from 3 minutes down to 15 seconds on my computer.

#### Related issue(s):