### PR TITLE
Travis CI : don't install dependencies unless they are used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,11 @@ before_install:
   # Speed up build time by disabling Xdebug.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   # Download and install the latest long-term support release of node.
-  - nvm install --lts
+  - if [[ "$SNIFF" == 1 ]]; then nvm install --lts; fi
   # Install Composer dependencies.
   - composer install
   # Install NPM dependencies.
-  - npm install
+  - if [[ "$SNIFF" == 1 ]]; then npm install; fi
 
 script:
   # Validate the composer.json file.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR seeks to optimize Travis build time by preventing the use of `nvm install` and `npm install` when Node.js is not used.