### PR TITLE
Added grid-template for no-sidebar

### DIFF
--- a/sass/layout/_no-sidebar.scss
+++ b/sass/layout/_no-sidebar.scss
@@ -1,12 +1,11 @@
 .no-sidebar {
 
-	.content-area {
-		float: none;
-		margin-left: auto;
-		margin-right: auto;
-	}
-
-	.site-main {
-		margin-right: 0;
+	.site {
+		display: grid;
+		grid-template-columns: auto;
+		grid-template-areas:
+			"header"
+			"main"
+			"footer";
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Modified \sass\layout\_no-sidebar.scss
Added grid-template-columns and grid-template-areas for { .site } when there is no sidebar.

#### Related issue(s):

No Sidebar has the 25% Blank Space. Needs to be adjusted grid-template for no-siderbar templates.