### PR TITLE
Remove font-size mixin

### DIFF
--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -7,9 +7,7 @@ input[type="submit"] {
 	border-radius: 3px;
 	background: $color__background-button;
 	color: rgba(0, 0, 0, 0.8);
-
 	font-size: 0.75rem;
-
 	line-height: 1;
 	padding: 0.6em 1em 0.4em;
 

--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -8,7 +8,7 @@ input[type="submit"] {
 	background: $color__background-button;
 	color: rgba(0, 0, 0, 0.8);
 
-	@include font-size(0.75);
+	font-size: 0.75rem;
 
 	line-height: 1;
 	padding: 0.6em 1em 0.4em;

--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -1,9 +1,3 @@
-// Rem output with px fallback
-@mixin font-size($sizeValue: 1) {
-	font-size: ($sizeValue * 16) * 1px;
-	font-size: $sizeValue * 1rem;
-}
-
 // Center block
 @mixin center-block {
 	display: block;

--- a/sass/modules/_accessibility.scss
+++ b/sass/modules/_accessibility.scss
@@ -19,9 +19,7 @@
 		clip-path: none;
 		color: $color__text-screen;
 		display: block;
-
 		font-size: 0.875rem;
-
 		font-weight: 700;
 		height: auto;
 		left: 5px;

--- a/sass/modules/_accessibility.scss
+++ b/sass/modules/_accessibility.scss
@@ -20,7 +20,7 @@
 		color: $color__text-screen;
 		display: block;
 
-		@include font-size(0.875);
+		font-size: 0.875rem;
 
 		font-weight: 700;
 		height: auto;

--- a/sass/typography/_copy.scss
+++ b/sass/typography/_copy.scss
@@ -20,7 +20,6 @@ address {
 pre {
 	background: $color__background-pre;
 	font-family: $font__pre;
-
 	font-size: 0.9375rem;
 	line-height: $font__line-height-pre;
 	margin-bottom: 1.6em;
@@ -34,7 +33,6 @@ kbd,
 tt,
 var {
 	font-family: $font__code;
-
 	font-size: 0.9375rem;
 }
 

--- a/sass/typography/_copy.scss
+++ b/sass/typography/_copy.scss
@@ -21,7 +21,7 @@ pre {
 	background: $color__background-pre;
 	font-family: $font__pre;
 
-	@include font-size(0.9375);
+	font-size: 0.9375rem;
 	line-height: $font__line-height-pre;
 	margin-bottom: 1.6em;
 	max-width: 100%;
@@ -35,7 +35,7 @@ tt,
 var {
 	font-family: $font__code;
 
-	@include font-size(0.9375);
+	font-size: 0.9375rem;
 }
 
 abbr,

--- a/sass/typography/_typography.scss
+++ b/sass/typography/_typography.scss
@@ -6,7 +6,6 @@ optgroup,
 textarea {
 	color: $color__text-main;
 	font-family: $font__main;
-
 	font-size: 1rem;
 	line-height: $font__line-height-body;
 }

--- a/sass/typography/_typography.scss
+++ b/sass/typography/_typography.scss
@@ -7,7 +7,7 @@ textarea {
 	color: $color__text-main;
 	font-family: $font__main;
 
-	@include font-size(1);
+	font-size: 1rem;
 	line-height: $font__line-height-body;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -368,7 +368,6 @@ optgroup,
 textarea {
 	color: #404040;
 	font-family: sans-serif;
-	font-size: 16px;
 	font-size: 1rem;
 	line-height: 1.5;
 }
@@ -404,7 +403,6 @@ address {
 pre {
 	background: #eee;
 	font-family: "Courier 10 Pitch", courier, monospace;
-	font-size: 15px;
 	font-size: 0.9375rem;
 	line-height: 1.6;
 	margin-bottom: 1.6em;
@@ -418,7 +416,6 @@ kbd,
 tt,
 var {
 	font-family: monaco, consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
-	font-size: 15px;
 	font-size: 0.9375rem;
 }
 
@@ -518,7 +515,6 @@ input[type="submit"] {
 	border-radius: 3px;
 	background: #e6e6e6;
 	color: rgba(0, 0, 0, 0.8);
-	font-size: 12px;
 	font-size: 0.75rem;
 	line-height: 1;
 	padding: 0.6em 1em 0.4em;
@@ -744,7 +740,6 @@ a:active {
 	clip-path: none;
 	color: #21759b;
 	display: block;
-	font-size: 14px;
 	font-size: 0.875rem;
 	font-weight: 700;
 	height: auto;

--- a/style.css
+++ b/style.css
@@ -368,7 +368,6 @@ optgroup,
 textarea {
 	color: #404040;
 	font-family: sans-serif;
-	font-size: 16px;
 	font-size: 1rem;
 	line-height: 1.5;
 }
@@ -404,7 +403,6 @@ address {
 pre {
 	background: #eee;
 	font-family: "Courier 10 Pitch", courier, monospace;
-	font-size: 15px;
 	font-size: 0.9375rem;
 	line-height: 1.6;
 	margin-bottom: 1.6em;
@@ -418,7 +416,6 @@ kbd,
 tt,
 var {
 	font-family: monaco, consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
-	font-size: 15px;
 	font-size: 0.9375rem;
 }
 
@@ -518,7 +515,6 @@ input[type="submit"] {
 	border-radius: 3px;
 	background: #e6e6e6;
 	color: rgba(0, 0, 0, 0.8);
-	font-size: 12px;
 	font-size: 0.75rem;
 	line-height: 1;
 	padding: 0.6em 1em 0.4em;
@@ -744,7 +740,6 @@ a:active {
 	clip-path: none;
 	color: #21759b;
 	display: block;
-	font-size: 14px;
 	font-size: 0.875rem;
 	font-weight: 700;
 	height: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Remove the font-size mixin now that we no longer need pixel fallback support for IE8 and below.

#### Related issue(s):