### PR TITLE
Use the system font stack from WP dashboard

### DIFF
--- a/sass/variables-site/_typography.scss
+++ b/sass/variables-site/_typography.scss
@@ -1,4 +1,6 @@
-$font__main: sans-serif;
+// stylelint-disable value-keyword-case
+$font__main: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+// stylelint-enable value-keyword-case
 $font__code: monaco, consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 $font__pre: "Courier 10 Pitch", courier, monospace;
 $font__line-height-body: 1.5;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -374,7 +374,7 @@ select,
 optgroup,
 textarea {
 	color: #404040;
-	font-family: sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1rem;
 	line-height: 1.5;
 }

--- a/style.css
+++ b/style.css
@@ -374,7 +374,7 @@ select,
 optgroup,
 textarea {
 	color: #404040;
-	font-family: sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 1rem;
 	line-height: 1.5;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Use the system font stack that WordPress 4.6 introduced for the dashboard:

- **-apple-system**: Safari (iOS & macOS) and Firefox macOS
- **BlinkMacSystemFont**: Chrome macOS
- **Segoe UI**: Windows
- **Roboto**: Android and Chrome OS
- **Oxygen-Sans**: KDE
- **Ubuntu**: Ubuntu
- **Cantarell**: GNOME
- **Helvetica Neue**: versions of macOS prior to 10.11
- **sans-serif**: the standard fallback 

The stylelint rule 'value-keyword-case' is disabled because font names are case sensitive on some systems.  Bootstrap also disables this rule for their font-family values.

#### Related issue(s):