### PR TITLE
Add a bundle script to generate a zip file for theme distribution

### DIFF
--- a/bin/bundle.js
+++ b/bin/bundle.js
@@ -13,6 +13,7 @@ const excludes = [
 	'.gitattributes',
 	'.github',
 	'.gitignore',
+	'README.md',
 	'bin',
 	'composer.json',
 	'composer.lock',

--- a/bin/bundle.js
+++ b/bin/bundle.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+const distinationDirectory = 'bundle';
+const excludes = [
+	'.DS_Store',
+	'.stylelintrc.json',
+	'.eslintrc',
+	'.git',
+	'.gitattributes',
+	'.github',
+	'.gitignore',
+	'bin',
+	'composer.json',
+	'composer.lock',
+	'node_modules',
+	'package-lock.json',
+	'package.json',
+	'vendor',
+	'.travis.yml',
+	'phpcs.xml.dist',
+	'sass',
+];
+
+function traverseDirectoryTree( directoryPath ) {
+	const files = fs.readdirSync( directoryPath );
+	for ( const i in files ) {
+		const currentPath = directoryPath + '/' + files[i];
+		const stats = fs.statSync( currentPath );
+		if ( stats.isFile() && ! excludes.includes( files[i] ) ) {
+			copyFile( currentPath );
+		} else if ( stats.isDirectory() && ! excludes.includes( files[i] ) ) {
+			traverseDirectoryTree( currentPath );
+		}
+	}
+}
+
+function copyFile( file ) {
+	const distinationPath = path.join(
+		__dirname,
+		'/../../',
+		distinationDirectory,
+		file
+	);
+
+	if ( ! fs.existsSync( path.dirname( distinationPath ) ) ) {
+		fs.mkdirSync( path.dirname( distinationPath ) );
+	}
+
+	fs.readFile( file, 'utf8', function( err, data ) {
+		fs.writeFile( distinationPath, data, 'utf8', function( err ) {
+			console.log( 'Copying' + file );
+			if ( err ) {
+				return console.log( err );
+			}
+		} );
+	} );
+}
+
+traverseDirectoryTree( '.' );

--- a/bin/bundle.js
+++ b/bin/bundle.js
@@ -2,8 +2,9 @@
 
 const path = require( 'path' );
 const fs = require( 'fs' );
+const archiver = require('archiver');
 
-const distinationDirectory = 'bundle';
+// Contains the excluded files and folders.
 const excludes = [
 	'.DS_Store',
 	'.stylelintrc.json',
@@ -24,39 +25,66 @@ const excludes = [
 	'sass',
 ];
 
+// The path of the zip file.
+const zipPath = path.join(
+	__dirname,
+	'/../../',
+	path.basename(path.dirname(__dirname))
+) + '.zip';
+
+
+// Create a file to stream archive data to.
+let output = fs.createWriteStream( zipPath );
+let archive = archiver('zip', {
+  zlib: { level: 9 }
+});
+
+/**
+ * Recursively traverse the directory tree and append the files to the archive. 
+ * @param {string} directoryPath - The path of the directory being looped through.
+ */
 function traverseDirectoryTree( directoryPath ) {
 	const files = fs.readdirSync( directoryPath );
 	for ( const i in files ) {
 		const currentPath = directoryPath + '/' + files[i];
 		const stats = fs.statSync( currentPath );
+		let relativePath = path.relative(process.cwd(), currentPath);
 		if ( stats.isFile() && ! excludes.includes( files[i] ) ) {
-			copyFile( currentPath );
+			archive.file(currentPath, {
+				name: `${relativePath}`
+			});
 		} else if ( stats.isDirectory() && ! excludes.includes( files[i] ) ) {
 			traverseDirectoryTree( currentPath );
 		}
 	}
 }
 
-function copyFile( file ) {
-	const distinationPath = path.join(
-		__dirname,
-		'/../../',
-		distinationDirectory,
-		file
-	);
+// Listen for all archive data to be written.
+output.on('close', function () {
+	console.log(`Created ${path.basename(path.dirname(__dirname))}.zip of ${archive.pointer()} bytes`);
+});
 
-	if ( ! fs.existsSync( path.dirname( distinationPath ) ) ) {
-		fs.mkdirSync( path.dirname( distinationPath ) );
+// Catch warnings during archiving.
+archive.on('warning', function(err) {
+	if (err.code === 'ENOENT') {
+		// log warning
+		console.log(err);
+	} else {
+		// throw error
+		throw err;
 	}
+});
 
-	fs.readFile( file, 'utf8', function( err, data ) {
-		fs.writeFile( distinationPath, data, 'utf8', function( err ) {
-			console.log( 'Copying' + file );
-			if ( err ) {
-				return console.log( err );
-			}
-		} );
-	} );
-}
+// Catch errors during archiving.
+archive.on('error', function(err){
+	throw err;
+});
 
+// Pipe archive data to the file.
+archive.pipe(output);
+
+// Append the files to the archive.
 traverseDirectoryTree( '.' );
+
+// Finalize the archive.
+archive.finalize();

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@wordpress/scripts": "^9.0.0",
+    "archiver": "^4.0.1",
     "node-sass": "^4.14.0",
     "rtlcss": "^2.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "compile:css": "node-sass sass/style.scss style.css && node-sass sass/woocommerce.scss woocommerce.css && stylelint '*.css' --fix || true && stylelint '*.css' --fix",
     "compile:rtl": "rtlcss style.css style-rtl.css",
     "lint:scss": "wp-scripts lint-style 'sass/**/*.scss'",
-    "lint:js": "wp-scripts lint-js 'js/*.js'"
+    "lint:js": "wp-scripts lint-js 'js/*.js'",
+    "bundle": "node bin/bundle.js"
   }
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a NodeJS script to generate a zip file for theme distribution, while excluding development and system files.

### Testing instructions:
To test this PR run `npm run bundle` in command line. A zip file containing only the essential theme files should be created in the parent directory of the actual theme. Note that the name of the zip file name should be the same as the theme directory name.