### PR TITLE
Update npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/Automattic/_s/issues"
   },
   "devDependencies": {
-    "@wordpress/scripts": "^8.0.1",
-    "node-sass": "^4.13.1",
+    "@wordpress/scripts": "^9.0.0",
+    "node-sass": "^4.14.0",
     "rtlcss": "^2.5.0"
   },
   "rtlcssConfig": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR updates `@wordpress/scripts` and `node-sass` packages.

One notable change is that `@wordpress/scripts` has stopped downloading Puppeteer's Chromium binary on install, instead, it will be downloaded on-demand when running test-e2e script, which prevent downloading 80Mb+ unnecessarily.
