### PR TITLE
Remove redundant font-size declarations

### DIFF
--- a/sass/base/elements/_buttons.scss
+++ b/sass/base/elements/_buttons.scss
@@ -7,7 +7,6 @@ input[type="submit"] {
 	border-radius: 3px;
 	background: $color__background-button;
 	color: rgba(0, 0, 0, 0.8);
-	font-size: 0.75rem;
 	line-height: 1;
 	padding: 0.6em 1em 0.4em;
 

--- a/sass/base/typography/_copy.scss
+++ b/sass/base/typography/_copy.scss
@@ -20,7 +20,6 @@ address {
 pre {
 	background: $color__background-pre;
 	font-family: $font__pre;
-	font-size: 0.9375rem;
 	line-height: $font__line-height-pre;
 	margin-bottom: 1.6em;
 	max-width: 100%;
@@ -33,7 +32,6 @@ kbd,
 tt,
 var {
 	font-family: $font__code;
-	font-size: 0.9375rem;
 }
 
 abbr,

--- a/sass/plugins/woocommerce/_components.scss
+++ b/sass/plugins/woocommerce/_components.scss
@@ -28,7 +28,6 @@
 	position: relative;
 	height: 1.618em;
 	line-height: 1.618;
-	font-size: 1em;
 	width: 5.3em;
 	font-family: star;
 	font-weight: 400;

--- a/sass/plugins/woocommerce/_products.scss
+++ b/sass/plugins/woocommerce/_products.scss
@@ -7,10 +7,6 @@ ul.products {
 		position: relative;
 		margin-bottom: 2em;
 
-		.woocommerce-loop-product__title {
-			font-size: 1rem;
-		}
-
 		img {
 			display: block;
 		}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -437,7 +437,6 @@ address {
 pre {
 	background: #eee;
 	font-family: "Courier 10 Pitch", courier, monospace;
-	font-size: 0.9375rem;
 	line-height: 1.6;
 	margin-bottom: 1.6em;
 	max-width: 100%;
@@ -450,7 +449,6 @@ kbd,
 tt,
 var {
 	font-family: monaco, consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
-	font-size: 0.9375rem;
 }
 
 abbr,
@@ -566,7 +564,6 @@ input[type="submit"] {
 	border-radius: 3px;
 	background: #e6e6e6;
 	color: rgba(0, 0, 0, 0.8);
-	font-size: 0.75rem;
 	line-height: 1;
 	padding: 0.6em 1em 0.4em;
 }

--- a/style.css
+++ b/style.css
@@ -437,7 +437,6 @@ address {
 pre {
 	background: #eee;
 	font-family: "Courier 10 Pitch", courier, monospace;
-	font-size: 0.9375rem;
 	line-height: 1.6;
 	margin-bottom: 1.6em;
 	max-width: 100%;
@@ -450,7 +449,6 @@ kbd,
 tt,
 var {
 	font-family: monaco, consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
-	font-size: 0.9375rem;
 }
 
 abbr,
@@ -566,7 +564,6 @@ input[type="submit"] {
 	border-radius: 3px;
 	background: #e6e6e6;
 	color: rgba(0, 0, 0, 0.8);
-	font-size: 0.75rem;
 	line-height: 1;
 	padding: 0.6em 1em 0.4em;
 }

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -82,10 +82,6 @@ ul.products li.product {
 	margin-bottom: 2em;
 }
 
-ul.products li.product .woocommerce-loop-product__title {
-	font-size: 1rem;
-}
-
 ul.products li.product img {
 	display: block;
 }
@@ -298,7 +294,6 @@ ul.products li.product .button {
 	position: relative;
 	height: 1.618em;
 	line-height: 1.618;
-	font-size: 1em;
 	width: 5.3em;
 	font-family: star;
 	font-weight: 400;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR prevent the duplication of `font-size:` property by removing it from the elements that have a `font-size:` declaration either in `normalize.css` or in the `body` tag.  This will help the body's children to inherit this property rather than redeclaring it multiple times.

#### Related issue(s):
Fixes : https://github.com/Automattic/_s/issues/1414