### PR TITLE
Exclude alignments classes from converting to RTL

### DIFF
--- a/sass/utilities/_alignments.scss
+++ b/sass/utilities/_alignments.scss
@@ -1,11 +1,19 @@
 .alignleft {
+
+	/*rtl:ignore*/
 	float: left;
+
+	/*rtl:ignore*/
 	margin-right: 1.5em;
 	margin-bottom: 1.5em;
 }
 
 .alignright {
+
+	/*rtl:ignore*/
 	float: right;
+
+	/*rtl:ignore*/
 	margin-left: 1.5em;
 	margin-bottom: 1.5em;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -941,14 +941,14 @@ textarea {
 /* Alignments
 --------------------------------------------- */
 .alignleft {
-	float: right;
-	margin-left: 1.5em;
+	float: left;
+	margin-right: 1.5em;
 	margin-bottom: 1.5em;
 }
 
 .alignright {
-	float: left;
-	margin-right: 1.5em;
+	float: right;
+	margin-left: 1.5em;
 	margin-bottom: 1.5em;
 }
 

--- a/style.css
+++ b/style.css
@@ -941,13 +941,21 @@ textarea {
 /* Alignments
 --------------------------------------------- */
 .alignleft {
+
+	/*rtl:ignore*/
 	float: left;
+
+	/*rtl:ignore*/
 	margin-right: 1.5em;
 	margin-bottom: 1.5em;
 }
 
 .alignright {
+
+	/*rtl:ignore*/
 	float: right;
+
+	/*rtl:ignore*/
 	margin-left: 1.5em;
 	margin-bottom: 1.5em;
 }


### PR DESCRIPTION
The styles of WordPress alignment classes `alignleft` and `alignright` should not change in the `style-rtl.css`, because normally they are only used  to float elements to the right or the left from the editor.