### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ npm install
 
 - `composer lint:wpcs` : checks all PHP files against [PHP Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/).
 - `composer lint:php` : checks all PHP files for syntax errors.
-- `composer make-pot` : generates a .pot file in the `language/` directory.
+- `composer make-pot` : generates a .pot file in the `languages/` directory.
 - `npm run compile:css` : compiles SASS files to css.
 - `npm run compile:rtl` : generates an RTL stylesheet.
 - `npm run watch` : watches all SASS files and recompiles them to css when they change.


### PR DESCRIPTION
Missing _s_ in `languages` directory name