### PR TITLE
Update composer and node dependencies

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -10,6 +10,7 @@
         "no-descending-specificity": null,
         "block-no-empty": null,
         "no-duplicate-selectors": null,
-        "font-family-no-duplicate-names": null
+        "font-family-no-duplicate-names": null,
+        "selector-class-pattern": null
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "wptrt/wpthemereview": "^0.2.1",
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
-        "wp-cli/i18n-command": "^2.2"
+        "wp-cli/i18n-command": "^2.2.5"
     },
     "scripts": {
         "lint:wpcs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "url": "https://github.com/Automattic/_s/issues"
   },
   "devDependencies": {
-    "@wordpress/scripts": "^9.0.0",
+    "@wordpress/scripts": "^12.1.0",
     "dir-archiver": "^1.1.1",
-    "node-sass": "^4.14.0",
+    "node-sass": "^4.14.1",
     "rtlcss": "^2.5.0"
   },
   "rtlcssConfig": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR update the following dependencies :

`dealerdirect/phpcodesniffer-composer-installer` from `0.6.2` to `0.7.0`.
`wp-cli/i18n-command` from `2.2` to `2.2.5`.
`@wordpress/scripts from` `9.0.0` to `12.1.0`.
`node-sass` from `4.14.0` to `4.14.1`.