### PR TITLE
Use _S_VERSION constant when enqueuing customizer.js

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -56,6 +56,6 @@ function _s_customize_partial_blogdescription() {
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
 function _s_customize_preview_js() {
-	wp_enqueue_script( '_s-customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), '20151215', true );
+	wp_enqueue_script( '_s-customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), _S_VERSION, true );
 }
 add_action( 'customize_preview_init', '_s_customize_preview_js' );


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
I propose that we use the constant "_S_VERSION" in the wp_enqueue_script function call instead of a static string.

#### Related issue(s):
None.