### PR TITLE
Add backward compatibility for wp_body_open function

### DIFF
--- a/header.php
+++ b/header.php
@@ -21,7 +21,15 @@
 </head>
 
 <body <?php body_class(); ?>>
-<?php wp_body_open(); ?>
+<?php
+if ( ! function_exists( 'wp_body_open' ) ) {
+	function wp_body_open() {
+		do_action( 'wp_body_open' );
+	}
+} else {
+	wp_body_open();
+}
+?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#primary"><?php esc_html_e( 'Skip to content', '_s' ); ?></a>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Add backward compatibility for wp_body_open function. as it was introduced in WordPress 5.2. Lots of themes use the _s theme as a base theme. So it's needed to add a check for backward compatibility.
#### Related issue(s): #1447 