### PR TITLE
Remove PHPCS Ignore Around $content-width Global

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -112,9 +112,6 @@ add_action( 'after_setup_theme', '_s_setup' );
  * @global int $content_width
  */
 function _s_content_width() {
-	// This variable is intended to be overruled from themes.
-	// Open WPCS issue: {@link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1043}.
-	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 	$GLOBALS['content_width'] = apply_filters( '_s_content_width', 640 );
 }
 add_action( 'after_setup_theme', '_s_content_width', 0 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The WordPress Coding Standards no longer show an error when the
$content-width global is overwritten. This PR removes the comment around
that global.

See: https://github.com/WordPress/WordPress-Coding-Standards/pull/1773