### PR TITLE
Improved the category output on posts

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -61,7 +61,7 @@ if ( ! function_exists( '_s_entry_footer' ) ) :
 		if ( 'post' === get_post_type() ) {
 			/* translators: used between list items, there is a space after the comma */
 			$categories_list = get_the_category_list( esc_html__( ', ', '_s' ) );
-			if ( $categories_list ) {
+			if ( $categories_list && has_category() ) {
 				/* translators: 1: list of categories. */
 				printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', '_s' ) . '</span>', $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}


### PR DESCRIPTION
When a post has no category assigned to it, not even the default Uncategorized category that WordPress assigns, the `_s_entry_footer()` function still outputs "Posted on Uncategorized". This PR fixes that. 

It appears as if this function was intended to display nothing when a post has no categories since it is checking if  `$categories_list` exists. The problem is this variable is set to "Uncategorized" by default if the post has no categories assigned. In this PR, we are simply adding the `has_category()` check to the conditional. Then, when a post has no categories, nothing is displayed as expected!
