### PR TITLE
Keep only relevant npm WordPress packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,13 @@
     "url": "https://github.com/Automattic/_s/issues"
   },
   "devDependencies": {
-    "@wordpress/scripts": "^12.1.0",
+    "@wordpress/eslint-plugin": "^7.2.1",
     "dir-archiver": "^1.1.1",
+    "eslint": "^7.9.0",
     "node-sass": "^4.14.1",
-    "rtlcss": "^2.5.0"
+    "rtlcss": "^2.5.0",
+    "stylelint": "^13.7.1",
+    "stylelint-config-wordpress": "^17.0.0"
   },
   "rtlcssConfig": {
     "options": {
@@ -39,8 +42,8 @@
     "watch": "node-sass sass/ -o ./ --source-map true --output-style expanded --indent-type tab --indent-width 1 -w",
     "compile:css": "node-sass sass/ -o ./ && stylelint '*.css' --fix || true && stylelint '*.css' --fix",
     "compile:rtl": "rtlcss style.css style-rtl.css",
-    "lint:scss": "wp-scripts lint-style 'sass/**/*.scss'",
-    "lint:js": "wp-scripts lint-js 'js/*.js'",
+    "lint:scss": "./node_modules/.bin/stylelint sass/**/*.scss",
+    "lint:js": "./node_modules/.bin/eslint js/*.js",
     "bundle": "dir-archiver --src . --dest ../_s.zip --exclude .DS_Store .stylelintrc.json .eslintrc .git .gitattributes .github .gitignore README.md composer.json composer.lock node_modules vendor package-lock.json package.json .travis.yml phpcs.xml.dist sass style.css.map"
   }
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The @wordpress/scripts npm module offers 13 scripts but only 2 are used by _s (). So I thought that adding only those two scripts to the project would improve it and it certainly did. Here is a comparison.

#### `npm install` Before the change
```sh
added 1884 packages from 774 contributors and audited 1887 packages in 53.306s
# ...
found 2 vulnerabilities
```
#### `npm install` After the change
```sh
added 604 packages from 373 contributors and audited 604 packages in 15.74s
# ...
found 0 vulnerabilities
```
#### Comparison
||Before|After|% Imprevement|
|-|-|-|-|
|Packages|1884|604|312%|
|Vulnerabilities|2|0|∞%|
|Time|53.306s|15.74s|339%|


