### PR TITLE
fix post date bug

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -14,15 +14,17 @@ if ( ! function_exists( '_s_posted_on' ) ) :
 	function _s_posted_on() {
 		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+			$time_string = sprintf(
+				$time_string,
+				esc_attr( get_the_modified_date( DATE_W3C ) ),
+				esc_html( get_the_modified_date() )
+			);
 		}
 
 		$time_string = sprintf(
 			$time_string,
 			esc_attr( get_the_date( DATE_W3C ) ),
-			esc_html( get_the_date() ),
-			esc_attr( get_the_modified_date( DATE_W3C ) ),
-			esc_html( get_the_modified_date() )
+			esc_html( get_the_date() )
 		);
 
 		$posted_on = sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
i choose to use underscore as the based theme for a new client theme and found out that the posted on date outputted two markup date once i change/modified the post.
So a peep into the underscore posted on function i found out that there is a code block outputting both  the published and modified date if the published date is not equal to the modified date.

So i assumed that the proposed behaviour is that if the published date is not equal to the modified date then output the modifed date.