### PR TITLE
Add option for excerpt

### DIFF
--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -33,20 +33,24 @@
 
 	<div class="entry-content">
 		<?php
-		the_content(
-			sprintf(
-				wp_kses(
-					/* translators: %s: Name of current post. Only visible to screen readers */
-					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', '_s' ),
-					array(
-						'span' => array(
-							'class' => array(),
-						),
-					)
-				),
-				wp_kses_post( get_the_title() )
-			)
-		);
+		if ( has_excerpt() ) :
+			the_excerpt();
+		else :
+			the_content(
+				sprintf(
+					wp_kses(
+						/* translators: %s: Name of current post. Only visible to screen readers */
+						__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', '_s' ),
+						array(
+							'span' => array(
+								'class' => array(),
+							),
+						)
+					),
+					wp_kses_post( get_the_title() )
+				)
+			);
+		endif;
 
 		wp_link_pages(
 			array(


### PR DESCRIPTION
Underscores only supports the use of "read more" inside of the content. But I think enough devs would like to have the option of the "classic" excerpt from the start. Also for some clients might be easier to understand/learn/use an excerpt that is outside of the content.