### PR TITLE
Replaced deprecated node-sass with sass (#1491)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 composer.lock
 style.css.map
 .DS_Store
+.idea/

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "devDependencies": {
     "@wordpress/scripts": "^19.2.2",
     "dir-archiver": "^1.1.1",
-    "node-sass": "^7.0.1",
-    "rtlcss": "^3.5.0"
+    "rtlcss": "^3.5.0",
+    "sass": "^1.35.1"
   },
   "rtlcssConfig": {
     "options": {
@@ -36,8 +36,8 @@
     "map": false
   },
   "scripts": {
-    "watch": "node-sass sass/ -o ./ --source-map true --output-style expanded --indent-type tab --indent-width 1 -w",
-    "compile:css": "node-sass sass/ -o ./ && stylelint '*.css' --fix || true && stylelint '*.css' --fix",
+    "watch": "sass sass/:./ --source-map --style expanded --indented -w",
+    "compile:css": "sass sass/:./ && stylelint *.css --fix || true && stylelint *.css --fix",
     "compile:rtl": "rtlcss style.css style-rtl.css",
     "lint:scss": "wp-scripts lint-style 'sass/**/*.scss'",
     "lint:js": "wp-scripts lint-js 'js/*.js'",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "map": false
   },
   "scripts": {
-    "watch": "sass sass/:./ --source-map --style expanded --indented -w",
+    "watch": "sass sass/:./ --source-map --style expanded -w",
     "compile:css": "sass sass/:./ && stylelint *.css --fix || true && stylelint *.css --fix",
     "compile:rtl": "rtlcss style.css style-rtl.css",
     "lint:scss": "wp-scripts lint-style 'sass/**/*.scss'",

--- a/sass/abstracts/mixins/_mixins.scss
+++ b/sass/abstracts/mixins/_mixins.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Center block
 @mixin center-block {
 	display: block;
@@ -7,5 +9,5 @@
 
 // Column width with margin
 @mixin column-width($numberColumns: 3) {
-	width: map-get($columns, $numberColumns) - ( ( $columns__margin * ( $numberColumns - 1 ) ) / $numberColumns );
+	width: map-get($columns, $numberColumns) - math.div(($columns__margin * ($numberColumns - 1)), $numberColumns);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- replaced node-sass with sass
- fixed a deprecation in _mixins.scss
- added PHPStorm's .idea/ to .gitignore

#### Related issue(s):

#1491 