### PR TITLE
fix: sass update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 composer.lock
 style.css.map
 .DS_Store
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@wordpress/scripts": "^19.2.2",
     "dir-archiver": "^1.1.1",
-    "node-sass": "^7.0.1",
+    "sass": "^1.64.1",
     "rtlcss": "^3.5.0"
   },
   "rtlcssConfig": {
@@ -36,8 +36,8 @@
     "map": false
   },
   "scripts": {
-    "watch": "node-sass sass/ -o ./ --source-map true --output-style expanded --indent-type tab --indent-width 1 -w",
-    "compile:css": "node-sass sass/ -o ./ && stylelint '*.css' --fix || true && stylelint '*.css' --fix",
+    "watch": "sass sass/:./ --style=expanded --no-charset --watch",
+    "compile:css": "sass sass/:./ --no-source-map --style=expanded --no-charset && stylelint '*.css' --fix || true && stylelint '*.css' --fix",
     "compile:rtl": "rtlcss style.css style-rtl.css",
     "lint:scss": "wp-scripts lint-style 'sass/**/*.scss'",
     "lint:js": "wp-scripts lint-js 'js/*.js'",


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
I recently got issues with node-sass in node 18 so I updated the sass compiler node-sass to normal sass here is the official sass documentation about that 
https://sass-lang.com/install/ https://prnt.sc/9s5XOenDOOvM

It is also updated .gitignore with yarn.lock because when we use yarn as a package manager, it's not required to load on the main repository. 


#### Related issue(s):

1. Sass update 
2. fixing yarn.lock ignore 